### PR TITLE
Add blog styling options and cover images

### DIFF
--- a/src/pages/BlogEditor.jsx
+++ b/src/pages/BlogEditor.jsx
@@ -8,6 +8,19 @@ export default function BlogEditor() {
   const navigate = useNavigate();
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
+  const [font, setFont] = useState('sans');
+  const [textColor, setTextColor] = useState('#000000');
+  const [bgColor, setBgColor] = useState('#ffffff');
+  const [coverImage, setCoverImage] = useState('');
+
+  function toBase64(file) {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result);
+      reader.onerror = reject;
+      reader.readAsDataURL(file);
+    });
+  }
 
   useEffect(() => {
     if (id) {
@@ -15,6 +28,10 @@ export default function BlogEditor() {
         if (post) {
           setTitle(post.title);
           setContent(post.content);
+          if (post.font) setFont(post.font);
+          if (post.textColor) setTextColor(post.textColor);
+          if (post.bgColor) setBgColor(post.bgColor);
+          if (post.coverImage) setCoverImage(post.coverImage);
         }
       });
     }
@@ -23,9 +40,24 @@ export default function BlogEditor() {
   const handleSave = async () => {
     if (!title.trim()) return;
     if (id) {
-      await db.posts.update(Number(id), { title, content });
+      await db.posts.update(Number(id), {
+        title,
+        content,
+        font,
+        textColor,
+        bgColor,
+        coverImage
+      });
     } else {
-      await db.posts.add({ title, content, createdAt: new Date() });
+      await db.posts.add({
+        title,
+        content,
+        createdAt: new Date(),
+        font,
+        textColor,
+        bgColor,
+        coverImage
+      });
     }
     navigate('/admin/blogs');
   };
@@ -48,6 +80,54 @@ export default function BlogEditor() {
           value={content}
           onChange={(e) => setContent(e.target.value)}
         />
+        <div className="flex space-x-4">
+          <label className="flex items-center space-x-2 text-sm">
+            <span>Font</span>
+            <select
+              className="border rounded p-1"
+              value={font}
+              onChange={(e) => setFont(e.target.value)}
+            >
+              <option value="sans">Sans</option>
+              <option value="serif">Serif</option>
+              <option value="mono">Mono</option>
+            </select>
+          </label>
+          <label className="flex items-center space-x-2 text-sm">
+            <span>Text</span>
+            <input
+              type="color"
+              value={textColor}
+              onChange={(e) => setTextColor(e.target.value)}
+            />
+          </label>
+          <label className="flex items-center space-x-2 text-sm">
+            <span>Background</span>
+            <input
+              type="color"
+              value={bgColor}
+              onChange={(e) => setBgColor(e.target.value)}
+            />
+          </label>
+        </div>
+        <div>
+          <label className="block text-sm mb-1">Cover Image</label>
+          <input
+            type="file"
+            accept="image/*"
+            onChange={async (e) => {
+              const file = e.target.files[0];
+              if (file) {
+                const data = await toBase64(file);
+                setCoverImage(data);
+              }
+            }}
+            className="block w-full text-sm text-gray-600"
+          />
+          {coverImage && (
+            <img src={coverImage} alt="cover" className="mt-2 h-40 object-cover rounded" />
+          )}
+        </div>
         <button
           onClick={handleSave}
           className="py-2 px-4 bg-emerald-600 text-white rounded-lg"

--- a/src/pages/BlogList.jsx
+++ b/src/pages/BlogList.jsx
@@ -32,8 +32,24 @@ export default function BlogList() {
       </div>
       <div className="space-y-4">
         {posts.map((post) => (
-          <div key={post.id} className="bg-white p-4 rounded-xl border">
-            <h3 className="text-lg font-semibold">{post.title}</h3>
+          <div
+            key={post.id}
+            className="p-4 rounded-xl border"
+            style={{ backgroundColor: post.bgColor || '#ffffff' }}
+          >
+            {post.coverImage && (
+              <img
+                src={post.coverImage}
+                alt="cover"
+                className="w-full h-40 object-cover rounded mb-2"
+              />
+            )}
+            <h3
+              className="text-lg font-semibold"
+              style={{ color: post.textColor || '#000000', fontFamily: post.font }}
+            >
+              {post.title}
+            </h3>
             <p className="text-sm text-gray-500 mb-2">
               {new Date(post.createdAt).toLocaleDateString()}
             </p>

--- a/src/pages/BlogView.jsx
+++ b/src/pages/BlogView.jsx
@@ -21,12 +21,31 @@ export default function BlogView() {
   return (
     <>
       <Header staticHeader={true} />
-      <main className="max-w-3xl mx-auto px-6 pt-32 pb-16">
-        <h1 className="text-3xl font-bold mb-6">{post.title}</h1>
+      <main
+        className="max-w-3xl mx-auto px-6 pt-32 pb-16"
+        style={{ backgroundColor: post.bgColor || '#ffffff' }}
+      >
+        {post.coverImage && (
+          <img
+            src={post.coverImage}
+            alt="cover"
+            className="w-full h-60 object-cover rounded mb-6"
+          />
+        )}
+        <h1
+          className="text-3xl font-bold mb-6"
+          style={{ color: post.textColor || '#000000', fontFamily: post.font }}
+        >
+          {post.title}
+        </h1>
         <p className="text-gray-500 mb-8">
           {new Date(post.createdAt).toLocaleDateString()}
         </p>
-        <div className="space-y-4" dangerouslySetInnerHTML={{ __html: post.content }} />
+        <div
+          className="space-y-4"
+          style={{ color: post.textColor || '#000000', fontFamily: post.font }}
+          dangerouslySetInnerHTML={{ __html: post.content }}
+        />
         <div className="mt-8">
           <Link to="/" className="text-emerald-600">← Back Home</Link>
         </div>

--- a/src/pages/Blogs.jsx
+++ b/src/pages/Blogs.jsx
@@ -25,9 +25,22 @@ export default function Blogs() {
             <Link
               key={post.id}
               to={`/blog/${post.id}`}
-              className="block p-4 bg-white rounded-xl border hover:bg-gray-50"
+              className="block p-4 rounded-xl border hover:bg-gray-50"
+              style={{ backgroundColor: post.bgColor || '#ffffff' }}
             >
-              <h3 className="text-lg font-semibold">{post.title}</h3>
+              {post.coverImage && (
+                <img
+                  src={post.coverImage}
+                  alt="cover"
+                  className="w-full h-40 object-cover rounded mb-2"
+                />
+              )}
+              <h3
+                className="text-lg font-semibold"
+                style={{ color: post.textColor || '#000000', fontFamily: post.font }}
+              >
+                {post.title}
+              </h3>
               <p className="text-sm text-gray-500">
                 {new Date(post.createdAt).toLocaleDateString()}
               </p>

--- a/src/utils/db.js
+++ b/src/utils/db.js
@@ -16,6 +16,14 @@ db.version(2).stores({
   posts: '++id, title, createdAt'
 });
 
+// v3 adds styling fields and cover images for blog posts
+db.version(3).stores({
+  campaigns: '++id, campaignName, createdAt',
+  creatives: '++id, name, url, type',
+  posts:
+    '++id, title, createdAt, font, textColor, bgColor, coverImage'
+});
+
 // Optional: helper methods
 export const addCampaign = async (campaign) => {
   return await db.campaigns.add(campaign);


### PR DESCRIPTION
## Summary
- support font, color and background customization for posts
- allow cover image upload with preview
- render cover images and styling on blog lists and individual posts
- extend IndexedDB schema for new fields

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686342452bcc832ea3667468725b8936