### PR TITLE
Fix blog editor visibility

### DIFF
--- a/src/components/blog/BlogEditor.jsx
+++ b/src/components/blog/BlogEditor.jsx
@@ -268,6 +268,7 @@ export default function BlogEditor() {
           value={content}
           onChange={setContent}
           modules={modules}
+          style={{ height: '300px' }}
         />
       )}
       {previewMode && (

--- a/src/index.css
+++ b/src/index.css
@@ -8,3 +8,8 @@ body {
   overflow-x: hidden;
   font-family: 'Inter', sans-serif;
 }
+
+/* Ensure Quill editor has visible height */
+.ql-container {
+  min-height: 300px;
+}


### PR DESCRIPTION
## Summary
- ensure the Quill editor is visible by giving it a fixed height
- set a minimum height for `.ql-container`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686359dc73e0832eb1f4997bddd90024