### PR TITLE
Redirect Get Started to Clerk sign-up

### DIFF
--- a/src/components/ContactUs.jsx
+++ b/src/components/ContactUs.jsx
@@ -20,10 +20,10 @@ export default function ContactUs() {
           </p>
   
           <a
-            href="mailto:founders@boardbid.ai"
+            href="/sign-up"
             className="px-6 py-3 bg-emerald-500 text-white font-semibold rounded-xl hover:bg-emerald-600 transition duration-300"
           >
-            Request Access
+            Get Started
           </a>
         </div>
       </section>

--- a/src/components/HeroSection.jsx
+++ b/src/components/HeroSection.jsx
@@ -75,10 +75,10 @@ export default function HeroSection() {
           .
         </p>
         <a
-          href="mailto:founders@boardbid.ai"
+          href="/sign-up"
           className="px-6 py-3 bg-emerald-500 text-white font-semibold rounded-xl hover:bg-emerald-600 transition duration-300"
         >
-          Request Access
+          Get Started
         </a>
       </div>
 


### PR DESCRIPTION
## Summary
- replace home page "Get Started" links with sign-up links
- direct hero and contact CTAs to Clerk sign-up screen

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688fac97aa48832e9a9273a16146d43e