### PR TITLE
fix: remove extra space in new campaign form

### DIFF
--- a/src/pages/NewCampaignPage.jsx
+++ b/src/pages/NewCampaignPage.jsx
@@ -1,4 +1,4 @@
-import InternalLayout from '../layout/InternalLayout';
+import InternalLayout from "../layout/InternalLayout";
 
 export default function NewCampaignPage() {
   return (
@@ -9,7 +9,7 @@ export default function NewCampaignPage() {
           className="airtable-embed airtable-dynamic-height w-full"
           frameBorder="0"
           onWheel=""
-          style={{ background: 'transparent', border: '1px solid #ccc', height: '2000px' }}
+          style={{ background: "transparent", border: "1px solid #ccc" }}
         />
       </div>
     </InternalLayout>


### PR DESCRIPTION
## Summary
- trim excess white space below the Airtable embed on the New Campaign page by removing the hard-coded height

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npm run build`
- `npx prettier src/pages/NewCampaignPage.jsx --check`


------
https://chatgpt.com/codex/tasks/task_e_689019ed8b38832ea604c815c7ddf67c