### PR TITLE
feat: redesign hero section

### DIFF
--- a/src/components/HeroSection.jsx
+++ b/src/components/HeroSection.jsx
@@ -39,7 +39,10 @@ export default function HeroSection() {
   }, []);
 
   return (
-    <section id="hero" className="relative isolate overflow-hidden bg-white">
+    <section
+      id="hero"
+      className="relative isolate overflow-hidden bg-white min-h-screen flex items-center"
+    >
       <svg
         aria-hidden="true"
         className="absolute inset-x-0 top-0 -z-10 h-[64rem] w-full stroke-gray-200 [mask-image:radial-gradient(32rem_32rem_at_center,white,transparent)]"
@@ -64,9 +67,14 @@ export default function HeroSection() {
         />
       </div>
 
-      <div className="mx-auto max-w-7xl px-6 pt-32 pb-24 sm:pt-40 sm:pb-32 lg:px-8 lg:pt-32">
+      <div className="mx-auto max-w-7xl px-6 py-24 sm:py-32 lg:px-8">
         <div className="mx-auto max-w-2xl lg:mx-0 lg:flex lg:items-center lg:gap-x-14">
           <div className="w-full lg:max-w-xl lg:flex-shrink-0 xl:max-w-2xl">
+            <img
+              src="https://ik.imagekit.io/boardbid/Billboard%20Illustration%20Curve.avif?updatedAt=1754315644156"
+              alt="BoardBid logo"
+              className="mb-8 h-32 w-auto"
+            />
             <h1 className="text-4xl font-semibold tracking-tight text-gray-900 sm:text-6xl">
               Programmatic DOOH advertising for ambitious brands
             </h1>
@@ -76,64 +84,20 @@ export default function HeroSection() {
               <span className="font-semibold text-gray-700">real-time pricing</span>, and{' '}
               <span className="font-semibold text-gray-700">zero agency friction</span>.
             </p>
-            <div className="mt-10 flex items-center gap-x-6">
+            <div className="mt-10 flex items-center">
               <SignUpButton mode="modal">
-                <button className="rounded-md bg-emerald-500 px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-emerald-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600">
-                  Get started
+                <button className="rounded-md bg-[#274c77] px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-[#274c77] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#274c77]">
+                  Request access
                 </button>
               </SignUpButton>
-              <a href="#how-it-works" className="text-sm font-semibold leading-6 text-gray-900">
-                Live demo <span aria-hidden="true">→</span>
-              </a>
             </div>
           </div>
-          <div className="mt-14 flex justify-end gap-8 sm:mt-20 sm:justify-start sm:pl-20 lg:mt-0 lg:pl-0">
-            <div className="ml-auto w-44 flex-none space-y-8 pt-32 sm:ml-0 sm:pt-80 lg:order-last lg:pt-36 xl:order-0 xl:pt-80">
-              <div className="relative">
-                <img
-                  src="https://images.unsplash.com/photo-1557804506-669a67965ba0?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&h=528&q=80"
-                  alt=""
-                  className="aspect-[2/3] w-full rounded-xl bg-gray-900/5 object-cover shadow-lg"
-                />
-                <div className="pointer-events-none absolute inset-0 rounded-xl ring-1 ring-inset ring-gray-900/10" />
-              </div>
-            </div>
-            <div className="mr-auto w-44 flex-none space-y-8 sm:mr-0 sm:pt-52 lg:pt-36">
-              <div className="relative">
-                <img
-                  src="https://images.unsplash.com/photo-1485217988980-11786ced9454?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&h=528&q=80"
-                  alt=""
-                  className="aspect-[2/3] w-full rounded-xl bg-gray-900/5 object-cover shadow-lg"
-                />
-                <div className="pointer-events-none absolute inset-0 rounded-xl ring-1 ring-inset ring-gray-900/10" />
-              </div>
-              <div className="relative">
-                <img
-                  src="https://images.unsplash.com/photo-1559136555-9303baea8ebd?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&crop=focalpoint&fp-x=.4&w=396&h=528&q=80"
-                  alt=""
-                  className="aspect-[2/3] w-full rounded-xl bg-gray-900/5 object-cover shadow-lg"
-                />
-                <div className="pointer-events-none absolute inset-0 rounded-xl ring-1 ring-inset ring-gray-900/10" />
-              </div>
-            </div>
-            <div className="w-44 flex-none space-y-8 pt-32 sm:pt-0">
-              <div className="relative">
-                <img
-                  src="https://images.unsplash.com/photo-1670272504528-790c24957dda?ixlib=rb-4.0.3&ixid=MnwxMjA3fDF8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&crop=left&w=400&h=528&q=80"
-                  alt=""
-                  className="aspect-[2/3] w-full rounded-xl bg-gray-900/5 object-cover shadow-lg"
-                />
-                <div className="pointer-events-none absolute inset-0 rounded-xl ring-1 ring-inset ring-gray-900/10" />
-              </div>
-              <div className="relative">
-                <img
-                  src="https://images.unsplash.com/photo-1670272505284-8faba1c31f7d?ixlib=rb-4.0.3&ixid=MnwxMjA3fDF8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&h=528&q=80"
-                  alt=""
-                  className="aspect-[2/3] w-full rounded-xl bg-gray-900/5 object-cover shadow-lg"
-                />
-                <div className="pointer-events-none absolute inset-0 rounded-xl ring-1 ring-inset ring-gray-900/10" />
-              </div>
-            </div>
+          <div className="mt-14 sm:mt-20 lg:mt-0 lg:flex-1">
+            <img
+              src="https://ik.imagekit.io/boardbid/Billboard%20Illustration%20Curve.avif?updatedAt=1754315644156"
+              alt="Billboard illustration"
+              className="w-full max-w-md mx-auto"
+            />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- make hero section full screen and include brand imagery
- simplify hero images and remove demo link
- update request access button styling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890c0946338832eaabaca8df6a31dfd