### PR TITLE
Integrate Clerk auth with protected routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ BoardBid.ai is a modern Demand-Side Platform (DSP) designed for ambitious startu
 - **React 18** — Component-based SPA
 - **Vite** — Lightning-fast dev server and build tool
 - **Tailwind CSS 3** — Utility-first styling
-- **React Router** — Route navigation (`/`, `/login`, `/sign-up`)
+- **React Router** — Route navigation (`/`, `/login`, `/sign-up`, `/account`)
 - **Lottie** — Scroll animations
 - **Cloudflare Pages** — Free static hosting & CDN
 
@@ -77,5 +77,7 @@ VITE_CLERK_PUBLISHABLE_KEY=pk_test_aW50ZW5zZS1zY29ycGlvbi00Ny5jbGVyay5hY2NvdW50c
 ```
 
 The application expects this key at runtime.
+
+Authenticated users can access dashboards, campaign tools, and manage their profile on `/account`.
 
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,23 +11,26 @@ import BlogList from './pages/BlogList';
 import BlogEditor from './pages/BlogEditor';
 import BlogView from './pages/BlogView';
 import Blogs from './pages/Blogs';
+import Account from './pages/Account';
+import ProtectedRoute from './components/ProtectedRoute';
 
 function App() {
   return (
     <Routes>
-      <Route path="/" element={<Home />} />
-      <Route path="/login" element={<SignInPage />} />
-      <Route path="/sign-up" element={<SignUpPage />} />
-      <Route path="/dashboard" element={<Dashboard />} />
-      <Route path="/campaign/new" element={<NewCampaignPage />} />
-      <Route path="/upload-creative" element={<UploadCreative />} />
-      <Route path="/admin" element={<Admin />} />
-      <Route path="/reports" element={<Reports />} /> {/* ✅ Add this route */}
-      <Route path="/admin/blogs" element={<BlogList />} />
-      <Route path="/admin/blogs/new" element={<BlogEditor />} />
-      <Route path="/admin/blogs/:id" element={<BlogEditor />} />
-      <Route path="/blog/:id" element={<BlogView />} />
-      <Route path="/blogs" element={<Blogs />} />
+        <Route path="/" element={<Home />} />
+        <Route path="/login" element={<SignInPage />} />
+        <Route path="/sign-up" element={<SignUpPage />} />
+        <Route path="/dashboard" element={<ProtectedRoute><Dashboard /></ProtectedRoute>} />
+        <Route path="/campaign/new" element={<ProtectedRoute><NewCampaignPage /></ProtectedRoute>} />
+        <Route path="/upload-creative" element={<ProtectedRoute><UploadCreative /></ProtectedRoute>} />
+        <Route path="/admin" element={<ProtectedRoute><Admin /></ProtectedRoute>} />
+        <Route path="/reports" element={<ProtectedRoute><Reports /></ProtectedRoute>} /> {/* ✅ Add this route */}
+        <Route path="/admin/blogs" element={<ProtectedRoute><BlogList /></ProtectedRoute>} />
+        <Route path="/admin/blogs/new" element={<ProtectedRoute><BlogEditor /></ProtectedRoute>} />
+        <Route path="/admin/blogs/:id" element={<ProtectedRoute><BlogEditor /></ProtectedRoute>} />
+        <Route path="/account" element={<ProtectedRoute><Account /></ProtectedRoute>} />
+        <Route path="/blog/:id" element={<BlogView />} />
+        <Route path="/blogs" element={<Blogs />} />
     </Routes>
   );
 }

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -62,11 +62,15 @@ export default function Header({ staticHeader = false }) {
             <button className="hover:text-emerald-600 transition">Sign Up</button>
           </SignUpButton>
         </SignedOut>
-        <SignedIn>
-          <Link to="/dashboard" className="hover:text-emerald-600 transition">Dashboard</Link>
-          <UserButton afterSignOutUrl="/" />
-        </SignedIn>
-      </nav>
-    </header>
-  );
-}
+          <SignedIn>
+            <Link to="/dashboard" className="hover:text-emerald-600 transition">Dashboard</Link>
+            <UserButton
+              afterSignOutUrl="/"
+              userProfileMode="navigation"
+              userProfileUrl="/account"
+            />
+          </SignedIn>
+        </nav>
+      </header>
+    );
+  }

--- a/src/components/ProtectedRoute.jsx
+++ b/src/components/ProtectedRoute.jsx
@@ -1,0 +1,12 @@
+import { SignedIn, SignedOut, RedirectToSignIn } from '@clerk/clerk-react';
+
+export default function ProtectedRoute({ children }) {
+  return (
+    <>
+      <SignedIn>{children}</SignedIn>
+      <SignedOut>
+        <RedirectToSignIn />
+      </SignedOut>
+    </>
+  );
+}

--- a/src/layout/InternalLayout.jsx
+++ b/src/layout/InternalLayout.jsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { Dialog, DialogBackdrop, DialogPanel, TransitionChild } from '@headlessui/react';
+import { UserButton } from '@clerk/clerk-react';
 import {
   Bars3Icon,
   ChartPieIcon,
@@ -140,19 +141,12 @@ export default function InternalLayout({ children }) {
                     ))}
                   </ul>
                 </li>
-                <li className="-mx-6 mt-auto">
-                  <Link
-                    to="#"
-                    className="flex items-center gap-x-4 px-6 py-3 text-sm/6 font-semibold text-white hover:bg-indigo-700"
-                  >
-                    <img
-                      alt=""
-                      src="https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80"
-                      className="size-8 rounded-full bg-indigo-700"
-                    />
-                    <span className="sr-only">Your profile</span>
-                    <span aria-hidden="true">Tom Cook</span>
-                  </Link>
+                <li className="-mx-6 mt-auto px-6 py-3">
+                  <UserButton
+                    afterSignOutUrl="/"
+                    userProfileMode="navigation"
+                    userProfileUrl="/account"
+                  />
                 </li>
               </ul>
             </nav>
@@ -165,14 +159,11 @@ export default function InternalLayout({ children }) {
             <Bars3Icon aria-hidden="true" className="size-6" />
           </button>
           <div className="flex-1 text-sm/6 font-semibold text-white">{currentPage}</div>
-          <Link to="#">
-            <span className="sr-only">Your profile</span>
-            <img
-              alt=""
-              src="https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80"
-              className="size-8 rounded-full bg-indigo-700"
-            />
-          </Link>
+          <UserButton
+            afterSignOutUrl="/"
+            userProfileMode="navigation"
+            userProfileUrl="/account"
+          />
         </div>
 
         <main className="py-10 lg:pl-72">

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,6 +1,6 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import { BrowserRouter } from 'react-router-dom';
+import { BrowserRouter, useNavigate } from 'react-router-dom';
 import { ClerkProvider } from '@clerk/clerk-react';
 import './index.css';
 import App from './App.jsx';
@@ -10,12 +10,26 @@ if (!PUBLISHABLE_KEY) {
   throw new Error('Missing Clerk Publishable Key');
 }
 
+function ClerkApp() {
+  const navigate = useNavigate();
+  return (
+    <ClerkProvider
+      publishableKey={PUBLISHABLE_KEY}
+      navigate={(to) => navigate(to)}
+      signInUrl="/login"
+      signUpUrl="/sign-up"
+      userProfileUrl="/account"
+      afterSignOutUrl="/"
+    >
+      <App />
+    </ClerkProvider>
+  );
+}
+
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <ClerkProvider publishableKey={PUBLISHABLE_KEY} afterSignOutUrl="/">
-      <BrowserRouter basename="/boardbid-ui">
-        <App />
-      </BrowserRouter>
-    </ClerkProvider>
+    <BrowserRouter basename="/boardbid-ui">
+      <ClerkApp />
+    </BrowserRouter>
   </StrictMode>,
 );

--- a/src/pages/Account.jsx
+++ b/src/pages/Account.jsx
@@ -1,0 +1,10 @@
+import { UserProfile } from '@clerk/clerk-react';
+import InternalLayout from '../layout/InternalLayout';
+
+export default function Account() {
+  return (
+    <InternalLayout>
+      <UserProfile />
+    </InternalLayout>
+  );
+}


### PR DESCRIPTION
## Summary
- wire ClerkProvider to React Router with custom URLs and sign-out handling
- add ProtectedRoute wrapper and account profile page
- use Clerk UserButton in headers and secure internal routes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689188f10090832eae78aea58df885fc