### PR TITLE
feat: integrate clerk auth

### DIFF
--- a/src/components/HeroSection.jsx
+++ b/src/components/HeroSection.jsx
@@ -3,7 +3,7 @@
 import { useState } from 'react'
 import { Dialog, DialogPanel } from '@headlessui/react'
 import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/outline'
-import { SignInButton, SignUpButton } from '@clerk/clerk-react'
+import { SignedIn, SignedOut, SignInButton, SignUpButton } from '@clerk/clerk-react'
 
 const navigation = [
   { name: 'Product', href: '#' },
@@ -47,11 +47,18 @@ export default function Hero() {
             ))}
           </div>
           <div className="hidden lg:flex lg:flex-1 lg:justify-end">
-            <SignInButton mode="modal" afterSignInUrl="/dashboard">
-              <button className="text-sm font-semibold text-white hover:text-indigo-400">
-                Log in <span aria-hidden="true">&rarr;</span>
-              </button>
-            </SignInButton>
+            <SignedOut>
+              <SignInButton mode="modal" afterSignInUrl="/dashboard">
+                <button className="text-sm font-semibold text-white hover:text-indigo-400">
+                  Log in <span aria-hidden="true">&rarr;</span>
+                </button>
+              </SignInButton>
+            </SignedOut>
+            <SignedIn>
+              <a href="/dashboard" className="text-sm font-semibold text-white hover:text-indigo-400">
+                Dashboard <span aria-hidden="true">&rarr;</span>
+              </a>
+            </SignedIn>
           </div>
         </nav>
 
@@ -88,11 +95,21 @@ export default function Hero() {
                   ))}
                 </div>
                 <div className="py-6">
-                  <SignInButton mode="modal" afterSignInUrl="/dashboard">
-                    <button className="-mx-3 block rounded-lg px-3 py-2.5 text-base font-semibold text-white hover:bg-gray-800">
-                      Log in
-                    </button>
-                  </SignInButton>
+                  <SignedOut>
+                    <SignInButton mode="modal" afterSignInUrl="/dashboard">
+                      <button className="-mx-3 block rounded-lg px-3 py-2.5 text-base font-semibold text-white hover:bg-gray-800">
+                        Log in
+                      </button>
+                    </SignInButton>
+                  </SignedOut>
+                  <SignedIn>
+                    <a
+                      href="/dashboard"
+                      className="-mx-3 block rounded-lg px-3 py-2.5 text-base font-semibold text-white hover:bg-gray-800"
+                    >
+                      Dashboard
+                    </a>
+                  </SignedIn>
                 </div>
               </div>
             </div>
@@ -126,11 +143,21 @@ export default function Hero() {
             <span className="font-semibold text-gray-100">zero agency friction</span>.
           </p>
           <div className="mt-10 flex items-center justify-center gap-x-6">
-            <SignUpButton mode="modal" afterSignUpUrl="/dashboard">
-              <button className="rounded-md bg-indigo-500 px-4 py-2.5 text-sm font-semibold text-white shadow hover:bg-indigo-400">
-                Get started
-              </button>
-            </SignUpButton>
+            <SignedOut>
+              <SignUpButton mode="modal" afterSignUpUrl="/dashboard">
+                <button className="rounded-md bg-indigo-500 px-4 py-2.5 text-sm font-semibold text-white shadow hover:bg-indigo-400">
+                  Get started
+                </button>
+              </SignUpButton>
+            </SignedOut>
+            <SignedIn>
+              <a
+                href="/dashboard"
+                className="rounded-md bg-indigo-500 px-4 py-2.5 text-sm font-semibold text-white shadow hover:bg-indigo-400"
+              >
+                Dashboard
+              </a>
+            </SignedIn>
             <a href="#" className="text-sm font-semibold text-gray-300 hover:text-white">
               Learn more <span aria-hidden="true">→</span>
             </a>

--- a/src/layout/InternalLayout.jsx
+++ b/src/layout/InternalLayout.jsx
@@ -6,10 +6,6 @@ import {
   Dialog,
   DialogBackdrop,
   DialogPanel,
-  Menu,
-  MenuButton,
-  MenuItem,
-  MenuItems,
   TransitionChild,
 } from '@headlessui/react';
 import {
@@ -23,7 +19,8 @@ import {
   UsersIcon,
   XMarkIcon,
 } from '@heroicons/react/24/outline';
-import { ChevronDownIcon, MagnifyingGlassIcon } from '@heroicons/react/20/solid';
+import { MagnifyingGlassIcon } from '@heroicons/react/20/solid';
+import { UserButton } from '@clerk/clerk-react';
 
 const navigation = [
   { name: 'Dashboard', href: '/dashboard', icon: HomeIcon },
@@ -36,10 +33,6 @@ const teams = [
   { id: 1, name: 'Heroicons', href: '#', initial: 'H', current: false },
   { id: 2, name: 'Tailwind Labs', href: '#', initial: 'T', current: false },
   { id: 3, name: 'Workcation', href: '#', initial: 'W', current: false },
-];
-const userNavigation = [
-  { name: 'Your profile', href: '#' },
-  { name: 'Sign out', href: '#' },
 ];
 
 function classNames(...classes) {
@@ -272,39 +265,11 @@ export default function InternalLayout({ children }) {
                 {/* Separator */}
                 <div aria-hidden="true" className="hidden lg:block lg:h-6 lg:w-px lg:bg-gray-900/10" />
 
-                {/* Profile dropdown */}
-                <Menu as="div" className="relative">
-                  <MenuButton className="relative flex items-center">
-                    <span className="absolute -inset-1.5" />
-                    <span className="sr-only">Open user menu</span>
-                    <img
-                      alt=""
-                      src="https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80"
-                      className="size-8 rounded-full bg-gray-50"
-                    />
-                    <span className="hidden lg:flex lg:items-center">
-                      <span aria-hidden="true" className="ml-4 text-sm/6 font-semibold text-gray-900">
-                        Tom Cook
-                      </span>
-                      <ChevronDownIcon aria-hidden="true" className="ml-2 size-5 text-gray-400" />
-                    </span>
-                  </MenuButton>
-                  <MenuItems
-                    transition
-                    className="absolute right-0 z-10 mt-2.5 w-32 origin-top-right rounded-md bg-white py-2 shadow-lg ring-1 ring-gray-900/5 transition focus:outline-hidden data-closed:scale-95 data-closed:transform data-closed:opacity-0 data-enter:duration-100 data-enter:ease-out data-leave:duration-75 data-leave:ease-in"
-                  >
-                    {userNavigation.map((item) => (
-                      <MenuItem key={item.name}>
-                        <a
-                          href={item.href}
-                          className="block px-3 py-1 text-sm/6 text-gray-900 data-focus:bg-gray-50 data-focus:outline-hidden"
-                        >
-                          {item.name}
-                        </a>
-                      </MenuItem>
-                    ))}
-                  </MenuItems>
-                </Menu>
+                <UserButton
+                  afterSignOutUrl="/"
+                  userProfileMode="navigation"
+                  userProfileUrl="/account"
+                />
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- integrate Clerk user button into dashboard layout
- show dashboard link on home page when signed in

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6891ca97775c832eb398d6864fe4f3ee