### PR TITLE
Add stats section and update integrations logos

### DIFF
--- a/src/components/Integrations.jsx
+++ b/src/components/Integrations.jsx
@@ -1,39 +1,60 @@
 // src/components/Integrations.jsx
 export default function Integrations() {
-    const partners = [
-      {
-        name: 'Hivestack',
-        src: 'https://ik.imagekit.io/boardbid/hivestack.avif?updatedAt=1748069727754',
-      },
-      {
-        name: 'Vistar Media',
-        src: 'https://ik.imagekit.io/boardbid/vistar-media.avif?updatedAt=1748069728193',
-      },
-      {
-        name: 'Place Exchange',
-        src: 'https://ik.imagekit.io/boardbid/place-exchange.avif?updatedAt=1748069728074',
-      },
-    ];
-  
-    return (
-      <section className="py-20 px-6 text-center bg-white animate-fadeIn mb-24">
-        <h2 className="text-3xl font-bold mb-6 animate-slideUp">
-          Planned SSP Integrations
-        </h2>
-        <p className="text-gray-600 mb-10">
-          We're preparing direct integrations with leading Supply-Side Platforms (SSPs):
-        </p>
-        <div className="flex justify-center items-center gap-10 flex-wrap">
-          {partners.map((p, i) => (
-            <img
-              key={i}
-              src={p.src}
-              alt={p.name}
-              className="h-12 grayscale hover:grayscale-0 opacity-80 hover:opacity-100 transition hover:scale-105"
-            />
-          ))}
+  const stats = [
+    { id: 1, name: 'Creators on the platform', value: '8,000+' },
+    { id: 2, name: 'Flat platform fee', value: '3%' },
+    { id: 3, name: 'Uptime guarantee', value: '99.9%' },
+    { id: 4, name: 'Paid out to creators', value: '$70M' },
+  ];
+
+  const partners = [
+    {
+      name: 'Hivestack',
+      src: 'https://ik.imagekit.io/boardbid/hivestack.avif?updatedAt=1748069727754',
+    },
+    {
+      name: 'Vistar Media',
+      src: 'https://ik.imagekit.io/boardbid/vistar-media.avif?updatedAt=1748069728193',
+    },
+    {
+      name: 'Place Exchange',
+      src: 'https://ik.imagekit.io/boardbid/place-exchange.avif?updatedAt=1748069728074',
+    },
+  ];
+
+  return (
+    <section className="py-20 px-6 text-center bg-white mb-24">
+      <div className="mx-auto max-w-7xl px-6 lg:px-8">
+        <div className="mx-auto max-w-2xl lg:max-w-none">
+          <div className="text-center">
+            <h2 className="text-4xl font-semibold tracking-tight text-balance text-gray-900 sm:text-5xl">
+              Trusted by creators worldwide
+            </h2>
+            <p className="mt-4 text-lg/8 text-gray-600">
+              Lorem ipsum dolor sit amet consect adipisicing possimus.
+            </p>
+          </div>
+          <dl className="mt-16 grid grid-cols-1 gap-0.5 overflow-hidden rounded-2xl text-center sm:grid-cols-2 lg:grid-cols-4">
+            {stats.map((stat) => (
+              <div key={stat.id} className="flex flex-col bg-gray-400/5 p-8">
+                <dt className="text-sm/6 font-semibold text-gray-600">
+                  {stat.name}
+                </dt>
+                <dd className="order-first text-3xl font-semibold tracking-tight text-gray-900">
+                  {stat.value}
+                </dd>
+              </div>
+            ))}
+          </dl>
         </div>
-      </section>
-    );
-  }
+      </div>
+      <p className="mt-16 text-gray-600">Powered by</p>
+      <div className="mt-6 flex justify-center items-center gap-10 flex-wrap">
+        {partners.map((p, i) => (
+          <img key={i} src={p.src} alt={p.name} className="h-8" />
+        ))}
+      </div>
+    </section>
+  );
+}
   


### PR DESCRIPTION
## Summary
- add platform stats to Integrations component
- show partner logos under stats with "Powered by" text
- simplify logo styling by removing fade effect and reducing logo size

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68945ffeed64832eb9bb80775e2cd2c8