### PR TITLE
Align landing page headings with Hero font

### DIFF
--- a/src/components/DashboardPreview.jsx
+++ b/src/components/DashboardPreview.jsx
@@ -2,7 +2,7 @@
 export default function DashboardPreview() {
   return (
     <section className="py-20 px-6 text-center bg-gray-50 animate-fadeIn mb-12">
-      <h2 className="text-3xl font-bold mb-6 animate-slideUp">Advertiser Dashboard Preview</h2>
+      <h2 className="text-3xl font-bold font-sans mb-6 animate-slideUp">Advertiser Dashboard Preview</h2>
       <p className="text-gray-600 mb-10">
         A glimpse into what our booking and reporting interface will look like.
       </p>

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -96,8 +96,8 @@ export default function Footer() {
       <div className="mx-auto max-w-7xl px-6 py-16 sm:py-24 lg:px-8 lg:py-32">
         <div className="mx-auto max-w-2xl text-center">
           <hgroup>
-          <h2 className="text-base/6 font-semibold text-indigo-400">Out-of-home, without the overwhelm</h2>
-            <p className="mt-2 text-4xl font-semibold tracking-tight text-white sm:text-5xl">
+          <h2 className="text-base/6 font-semibold font-sans text-indigo-400">Out-of-home, without the overwhelm</h2>
+            <p className="mt-2 text-4xl font-semibold font-sans tracking-tight text-white sm:text-5xl">
               Turn Heads. Drive Growth.
             </p>
           </hgroup>
@@ -123,7 +123,7 @@ export default function Footer() {
           <div className="mt-16 grid grid-cols-2 gap-8 xl:col-span-2 xl:mt-0">
             <div className="md:grid md:grid-cols-2 md:gap-8">
               <div>
-                <h3 className="text-sm/6 font-semibold text-white">Solutions</h3>
+                <h3 className="text-sm/6 font-semibold font-sans text-white">Solutions</h3>
                 <ul role="list" className="mt-6 space-y-4">
                   {navigation.solutions.map((item) => (
                     <li key={item.name}>
@@ -135,7 +135,7 @@ export default function Footer() {
                 </ul>
               </div>
               <div className="mt-10 md:mt-0">
-                <h3 className="text-sm/6 font-semibold text-white">Support</h3>
+                <h3 className="text-sm/6 font-semibold font-sans text-white">Support</h3>
                 <ul role="list" className="mt-6 space-y-4">
                   {navigation.support.map((item) => (
                     <li key={item.name}>
@@ -149,7 +149,7 @@ export default function Footer() {
             </div>
             <div className="md:grid md:grid-cols-2 md:gap-8">
               <div>
-                <h3 className="text-sm/6 font-semibold text-white">Company</h3>
+                <h3 className="text-sm/6 font-semibold font-sans text-white">Company</h3>
                 <ul role="list" className="mt-6 space-y-4">
                   {navigation.company.map((item) => (
                     <li key={item.name}>
@@ -161,7 +161,7 @@ export default function Footer() {
                 </ul>
               </div>
               <div className="mt-10 md:mt-0">
-                <h3 className="text-sm/6 font-semibold text-white">Legal</h3>
+                <h3 className="text-sm/6 font-semibold font-sans text-white">Legal</h3>
                 <ul role="list" className="mt-6 space-y-4">
                   {navigation.legal.map((item) => (
                     <li key={item.name}>

--- a/src/components/HowItWorks.jsx
+++ b/src/components/HowItWorks.jsx
@@ -68,7 +68,7 @@ export default function HowItWorks() {
       id="how-it-works"
       className="scroll-mt-32 py-20 px-6 text-center bg-gray-50 animate-fadeIn mb-24"
     >
-      <h2 className="text-3xl font-bold mb-12 animate-slideUp">How It Works</h2>
+      <h2 className="text-3xl font-bold font-sans mb-12 animate-slideUp">How It Works</h2>
 
       <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-6 max-w-6xl mx-auto">
         {steps.map((step, index) => (
@@ -88,7 +88,7 @@ export default function HowItWorks() {
                 {step.svg}
               </svg>
             </div>
-            <h3 className="text-xl font-semibold mb-2">{step.title}</h3>
+            <h3 className="text-xl font-semibold font-sans mb-2">{step.title}</h3>
             <p className="text-sm text-gray-500 border-t border-gray-200 mt-4 pt-3">
               {step.description}
             </p>

--- a/src/components/Integrations.jsx
+++ b/src/components/Integrations.jsx
@@ -19,7 +19,7 @@ export default function Integrations() {
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
         <div className="mx-auto max-w-2xl lg:max-w-none">
           <div className="text-center">
-            <h2 className="text-4xl font-semibold tracking-tight text-gray-900 sm:text-5xl">
+            <h2 className="text-4xl font-semibold font-sans tracking-tight text-gray-900 sm:text-5xl">
               Our Unparalleled Reach
             </h2>
             <p className="mt-2 text-lg text-gray-600">

--- a/src/components/WhyChoose.jsx
+++ b/src/components/WhyChoose.jsx
@@ -13,7 +13,7 @@ export default function WhyChoose() {
         />
       </div>
 
-      <h2 className="text-3xl font-bold mb-6 animate-slideUp">Why Choose BoardBid.ai?</h2>
+      <h2 className="text-3xl font-bold font-sans mb-6 animate-slideUp">Why Choose BoardBid.ai?</h2>
 
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 max-w-6xl mx-auto">
         {[
@@ -38,7 +38,7 @@ export default function WhyChoose() {
             key={i}
             className="p-6 bg-white rounded-xl border border-gray-200 shadow hover:shadow-lg transform transition-transform hover:-translate-y-2"
           >
-            <h3 className="text-xl font-semibold mb-2">{item.title}</h3>
+            <h3 className="text-xl font-semibold font-sans mb-2">{item.title}</h3>
             <p className="text-gray-600">{item.desc}</p>
           </div>
         ))}
@@ -58,7 +58,7 @@ export default function WhyChoose() {
             />
           </div>
           <div className="text-left lg:w-2/3">
-            <h3 className="text-2xl font-bold mb-4 text-gray-800">Our Philosophy</h3>
+            <h3 className="text-2xl font-bold font-sans mb-4 text-gray-800">Our Philosophy</h3>
             <p className="text-gray-700 text-base md:text-lg leading-relaxed">
               <strong>BoardBid.ai</strong> is a modern DSP purpose-built for high-growth startups and emerging brands — from launch to IPO — to plan and book out-of-home media without bloated agency fees or delays.
               <br /><br />


### PR DESCRIPTION
## Summary
- use Hero section font (`font-sans`) on headings in landing page sections
- apply same font to footer headings

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint .` *(fails: Global "AudioWorkletGlobalScope " has leading/trailing whitespace)*

------
https://chatgpt.com/codex/tasks/task_e_6894824890d0832eb9262f014566e433