### PR TITLE
fix: export components correctly

### DIFF
--- a/src/components/Integrations.jsx
+++ b/src/components/Integrations.jsx
@@ -6,7 +6,7 @@ const stats = [
   { id: 5, name: 'Countries', value: '22' },
 ];
 
-export function Integrations() {
+export default function Integrations() {
   return (
     <div className="bg-white py-24 sm:py-32">
       <div className="mx-auto max-w-7xl px-6 lg:px-8">

--- a/src/components/TargetLocations.jsx
+++ b/src/components/TargetLocations.jsx
@@ -1,4 +1,4 @@
-export function TargetLocations() {
+export default function TargetLocations() {
     return (
       <div className="bg-white py-24 sm:py-32">
         <div className="mx-auto max-w-2xl px-6 lg:max-w-7xl lg:px-8">


### PR DESCRIPTION
## Summary
- export Integrations and TargetLocations as default components so Home page can import them

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689494db2c78832ebedbf8c8f6cf01bb