### PR TITLE
Refactor footer navigation and add routes for new pages

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,12 @@ import NewCampaignPage from './pages/NewCampaignPage';
 import UploadCreative from './pages/UploadCreative';
 import Reports from './pages/Reports';
 import Account from './pages/Account';
+import TermsOfService from './pages/TermsOfService';
+import PrivacyPolicy from './pages/PrivacyPolicy';
+import Blogs from './pages/Blogs';
+import About from './pages/About';
+import Press from './pages/Press';
+import Support from './pages/Support';
 import ProtectedRoute from './components/ProtectedRoute';
 
 function App() {
@@ -20,6 +26,12 @@ function App() {
         <Route path="/upload-creative" element={<ProtectedRoute><UploadCreative /></ProtectedRoute>} />
         <Route path="/reports" element={<ProtectedRoute><Reports /></ProtectedRoute>} /> {/* ✅ Add this route */}
         <Route path="/account" element={<ProtectedRoute><Account /></ProtectedRoute>} />
+        <Route path="/blogs" element={<Blogs />} />
+        <Route path="/about" element={<About />} />
+        <Route path="/press" element={<Press />} />
+        <Route path="/support" element={<Support />} />
+        <Route path="/terms" element={<TermsOfService />} />
+        <Route path="/privacy" element={<PrivacyPolicy />} />
     </Routes>
   );
 }

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,28 +1,17 @@
 // src/components/Footer.jsx
 import { SignUpButton } from '@clerk/clerk-react';
+import { Link } from 'react-router-dom';
 
 const navigation = {
-  solutions: [
-    { name: 'Marketing', href: '#' },
-    { name: 'Analytics', href: '#' },
-    { name: 'Automation', href: '#' },
-    { name: 'Commerce', href: '#' },
-    { name: 'Insights', href: '#' },
+  support: [{ name: 'Submit ticket', href: '/support' }],
+  company: [
+    { name: 'About', href: '/about' },
+    { name: 'Blogs', href: '/blogs' },
+    { name: 'Press', href: '/press' },
   ],
-  support: [
-    { name: 'Submit ticket', href: '#' },
-    { name: 'Documentation', href: '#' },
-    { name: 'Guides', href: '#' },
-  ],
-    company: [
-      { name: 'About', href: '#' },
-      { name: 'Jobs', href: '#' },
-      { name: 'Press', href: '#' },
-    ],
   legal: [
-    { name: 'Terms of service', href: '#' },
-    { name: 'Privacy policy', href: '#' },
-    { name: 'License', href: '#' },
+    { name: 'Terms of Service', href: '/terms' },
+    { name: 'Privacy Policy', href: '/privacy' },
   ],
   social: [
     {
@@ -119,58 +108,42 @@ export default function Footer() {
             src="https://ik.imagekit.io/boardbid/BoardBid%20logo-White.svg?updatedAt=1754722842401"
             className="h-8"
           />
-          <div className="mt-16 grid grid-cols-2 gap-8 xl:col-span-2 xl:mt-0">
-            <div className="md:grid md:grid-cols-2 md:gap-8">
-              <div>
-                <h3 className="text-sm/6 font-semibold font-sans text-white">Solutions</h3>
-                <ul role="list" className="mt-6 space-y-4">
-                  {navigation.solutions.map((item) => (
-                    <li key={item.name}>
-                      <a href={item.href} className="text-sm/6 text-gray-400 hover:text-white">
-                        {item.name}
-                      </a>
-                    </li>
-                  ))}
-                </ul>
-              </div>
-              <div className="mt-10 md:mt-0">
-                <h3 className="text-sm/6 font-semibold font-sans text-white">Support</h3>
-                <ul role="list" className="mt-6 space-y-4">
-                  {navigation.support.map((item) => (
-                    <li key={item.name}>
-                      <a href={item.href} className="text-sm/6 text-gray-400 hover:text-white">
-                        {item.name}
-                      </a>
-                    </li>
-                  ))}
-                </ul>
-              </div>
+          <div className="mt-16 grid grid-cols-1 gap-8 md:grid-cols-3 xl:col-span-2 xl:mt-0">
+            <div>
+              <h3 className="text-sm/6 font-semibold font-sans text-white">Support</h3>
+              <ul role="list" className="mt-6 space-y-4">
+                {navigation.support.map((item) => (
+                  <li key={item.name}>
+                    <Link to={item.href} className="text-sm/6 text-gray-400 hover:text-white">
+                      {item.name}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
             </div>
-            <div className="md:grid md:grid-cols-2 md:gap-8">
-              <div>
-                <h3 className="text-sm/6 font-semibold font-sans text-white">Company</h3>
-                <ul role="list" className="mt-6 space-y-4">
-                  {navigation.company.map((item) => (
-                    <li key={item.name}>
-                      <a href={item.href} className="text-sm/6 text-gray-400 hover:text-white">
-                        {item.name}
-                      </a>
-                    </li>
-                  ))}
-                </ul>
-              </div>
-              <div className="mt-10 md:mt-0">
-                <h3 className="text-sm/6 font-semibold font-sans text-white">Legal</h3>
-                <ul role="list" className="mt-6 space-y-4">
-                  {navigation.legal.map((item) => (
-                    <li key={item.name}>
-                      <a href={item.href} className="text-sm/6 text-gray-400 hover:text-white">
-                        {item.name}
-                      </a>
-                    </li>
-                  ))}
-                </ul>
-              </div>
+            <div>
+              <h3 className="text-sm/6 font-semibold font-sans text-white">Company</h3>
+              <ul role="list" className="mt-6 space-y-4">
+                {navigation.company.map((item) => (
+                  <li key={item.name}>
+                    <Link to={item.href} className="text-sm/6 text-gray-400 hover:text-white">
+                      {item.name}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <div>
+              <h3 className="text-sm/6 font-semibold font-sans text-white">Legal</h3>
+              <ul role="list" className="mt-6 space-y-4">
+                {navigation.legal.map((item) => (
+                  <li key={item.name}>
+                    <Link to={item.href} className="text-sm/6 text-gray-400 hover:text-white">
+                      {item.name}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
             </div>
           </div>
         </div>

--- a/src/pages/About.jsx
+++ b/src/pages/About.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import Header from '../components/Header';
+import Footer from '../components/Footer';
+
+export default function About() {
+  return (
+    <>
+      <Header staticHeader />
+      <main className="mx-auto max-w-4xl px-6 py-16">
+        <h1 className="text-3xl font-bold mb-4">About</h1>
+        <p className="text-gray-600">Learn more about BoardBid.ai.</p>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/src/pages/Blogs.jsx
+++ b/src/pages/Blogs.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import Header from '../components/Header';
+import Footer from '../components/Footer';
+import BlogFlyer from '../components/BlogFlyer';
+
+export default function Blogs() {
+  return (
+    <>
+      <Header staticHeader />
+      <BlogFlyer />
+      <Footer />
+    </>
+  );
+}

--- a/src/pages/Press.jsx
+++ b/src/pages/Press.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import Header from '../components/Header';
+import Footer from '../components/Footer';
+
+export default function Press() {
+  return (
+    <>
+      <Header staticHeader />
+      <main className="mx-auto max-w-4xl px-6 py-16">
+        <h1 className="text-3xl font-bold mb-4">Press</h1>
+        <p className="text-gray-600">Read the latest news about BoardBid.ai.</p>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/src/pages/Support.jsx
+++ b/src/pages/Support.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import Header from '../components/Header';
+import Footer from '../components/Footer';
+
+export default function Support() {
+  return (
+    <>
+      <Header staticHeader />
+      <main className="mx-auto max-w-4xl px-6 py-16">
+        <h1 className="text-3xl font-bold mb-4">Support</h1>
+        <p className="text-gray-600">Submit a ticket and we'll get back to you shortly.</p>
+      </main>
+      <Footer />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- Simplify footer by removing Solutions, trimming Support, replacing Jobs with Blogs, and linking legal pages.
- Convert footer navigation to React Router links and add placeholder pages with routes for Blogs, About, Press, Support, Terms, and Privacy.

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a071a74ec832e9642835245de18c2