### PR TITLE
Add welcome back dashboard component and remove search bar

### DIFF
--- a/src/components/WelcomeBack.jsx
+++ b/src/components/WelcomeBack.jsx
@@ -1,0 +1,55 @@
+import { useUser } from '@clerk/clerk-react';
+
+const stats = [
+  { label: 'Vacation days left', value: 12 },
+  { label: 'Sick days left', value: 4 },
+  { label: 'Personal days left', value: 2 },
+];
+
+export default function WelcomeBack() {
+  const { user } = useUser();
+
+  return (
+    <div className="overflow-hidden rounded-lg bg-white shadow-sm dark:bg-gray-900 dark:shadow-none dark:outline dark:-outline-offset-1 dark:outline-white/10">
+      <h2 id="profile-overview-title" className="sr-only">
+        Profile Overview
+      </h2>
+      <div className="bg-white p-6 dark:bg-gray-800/75">
+        <div className="sm:flex sm:items-center sm:justify-between">
+          <div className="sm:flex sm:space-x-5">
+            <div className="shrink-0">
+              <img
+                alt=""
+                src={user?.imageUrl}
+                className="mx-auto size-20 rounded-full dark:outline dark:-outline-offset-1 dark:outline-white/10"
+              />
+            </div>
+            <div className="mt-4 text-center sm:mt-0 sm:pt-1 sm:text-left">
+              <p className="text-sm font-medium text-gray-600 dark:text-gray-400">Welcome back,</p>
+              <p className="text-xl font-bold text-gray-900 sm:text-2xl dark:text-white">{user?.fullName}</p>
+              <p className="text-sm font-medium text-gray-600 dark:text-gray-400">
+                {user?.primaryEmailAddress?.emailAddress}
+              </p>
+            </div>
+          </div>
+          <div className="mt-5 flex justify-center sm:mt-0">
+            <a
+              href="/account"
+              className="flex items-center justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-xs inset-ring inset-ring-gray-300 hover:bg-gray-50 dark:bg-white/10 dark:text-white dark:shadow-none dark:inset-ring-white/5 dark:hover:bg-white/20"
+            >
+              View profile
+            </a>
+          </div>
+        </div>
+      </div>
+      <div className="grid grid-cols-1 divide-y divide-gray-200 border-t border-gray-200 bg-gray-50 sm:grid-cols-3 sm:divide-x sm:divide-y-0 dark:divide-white/10 dark:border-white/10 dark:bg-gray-800/50">
+        {stats.map((stat) => (
+          <div key={stat.label} className="px-6 py-5 text-center text-sm font-medium">
+            <span className="text-gray-900 dark:text-white">{stat.value}</span>{' '}
+            <span className="text-gray-600 dark:text-gray-400">{stat.label}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/layout/InternalLayout.jsx
+++ b/src/layout/InternalLayout.jsx
@@ -19,7 +19,6 @@ import {
   UsersIcon,
   XMarkIcon,
 } from '@heroicons/react/24/outline';
-import { MagnifyingGlassIcon } from '@heroicons/react/20/solid';
 import { UserButton } from '@clerk/clerk-react';
 
 const navigation = [
@@ -231,17 +230,7 @@ export default function InternalLayout({ children }) {
               <Bars3Icon className="size-6" />
             </button>
             <div aria-hidden="true" className="h-6 w-px bg-gray-200 lg:hidden" />
-            <div className="flex flex-1 gap-x-4 self-stretch lg:gap-x-6">
-              <form action="#" method="GET" className="grid flex-1 grid-cols-1">
-                <input
-                  name="search"
-                  type="search"
-                  placeholder="Search"
-                  aria-label="Search"
-                  className="col-start-1 row-start-1 block size-full bg-white pl-8 text-base text-gray-900 outline-hidden placeholder:text-gray-400 sm:text-sm/6"
-                />
-                <MagnifyingGlassIcon className="pointer-events-none col-start-1 row-start-1 size-5 self-center text-gray-400" />
-              </form>
+            <div className="flex flex-1 justify-end gap-x-4 self-stretch lg:gap-x-6">
               <div className="flex items-center gap-x-4 lg:gap-x-6">
                 <button type="button" className="-m-2.5 p-2.5 text-gray-400 hover:text-gray-500">
                   <span className="sr-only">View notifications</span>

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,35 +1,10 @@
-import { useUser } from '@clerk/clerk-react';
 import InternalLayout from '../layout/InternalLayout';
+import WelcomeBack from '../components/WelcomeBack';
 
 export default function Dashboard() {
-  const { user } = useUser();
-  const userEmail = user?.primaryEmailAddress?.emailAddress;
-
   return (
     <InternalLayout>
-      {/* Welcome Header */}
-      <div className="mb-8">
-        <h1 className="text-3xl font-bold text-gray-800">Welcome back 👋</h1>
-        <p className="text-sm text-gray-600 mt-1">
-          Logged in as: <span className="font-medium">{userEmail}</span>
-        </p>
-      </div>
-
-      {/* Summary Cards */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 mb-10">
-        <div className="bg-white p-6 rounded-xl shadow text-center">
-          <h3 className="text-lg font-semibold text-gray-700">Active Campaigns</h3>
-          <p className="text-3xl font-bold text-emerald-500 mt-2">3</p>
-        </div>
-        <div className="bg-white p-6 rounded-xl shadow text-center">
-          <h3 className="text-lg font-semibold text-gray-700">Total Spend</h3>
-          <p className="text-3xl font-bold text-yellow-500 mt-2">$12,430</p>
-        </div>
-        <div className="bg-white p-6 rounded-xl shadow text-center">
-          <h3 className="text-lg font-semibold text-gray-700">Impressions</h3>
-          <p className="text-3xl font-bold text-purple-500 mt-2">2.1M</p>
-        </div>
-      </div>
+      <WelcomeBack />
     </InternalLayout>
   );
 }


### PR DESCRIPTION
## Summary
- add WelcomeBack component using Clerk user data
- simplify Dashboard to render the new component
- remove layout search bar and related icon

## Testing
- `npm test` *(fails: Missing script "test"*)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a1deba38c832e93c2a996769f7cb7