### PR TITLE
Fix auth redirects and reorganize sidebar

### DIFF
--- a/src/components/WelcomeBack.jsx
+++ b/src/components/WelcomeBack.jsx
@@ -1,4 +1,5 @@
 import { useUser } from '@clerk/clerk-react';
+import { Link } from 'react-router-dom';
 
 const stats = [
 ];
@@ -30,12 +31,12 @@ export default function WelcomeBack() {
             </div>
           </div>
           <div className="mt-5 flex justify-center sm:mt-0">
-            <a
-              href="/account"
+            <Link
+              to="/account"
               className="flex items-center justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-xs inset-ring inset-ring-gray-300 hover:bg-gray-50 dark:bg-white/10 dark:text-white dark:shadow-none dark:inset-ring-white/5 dark:hover:bg-white/20"
             >
               View profile
-            </a>
+            </Link>
           </div>
         </div>
       </div>

--- a/src/layout/InternalLayout.jsx
+++ b/src/layout/InternalLayout.jsx
@@ -12,11 +12,9 @@ import {
   Bars3Icon,
   BellIcon,
   ChartPieIcon,
-  Cog6ToothIcon,
   DocumentDuplicateIcon,
   FolderIcon,
   HomeIcon,
-  UsersIcon,
   XMarkIcon,
 } from '@heroicons/react/24/outline';
 import { UserButton } from '@clerk/clerk-react';
@@ -95,7 +93,7 @@ export default function InternalLayout({ children }) {
                         ))}
                       </ul>
                     </li>
-                    <li>
+                    <li className="mt-auto">
                       <div className="text-xs/6 font-semibold text-gray-400">Your teams</div>
                       <ul role="list" className="-mx-2 mt-2 space-y-1">
                         {teams.map((team) => (
@@ -124,15 +122,6 @@ export default function InternalLayout({ children }) {
                           </li>
                         ))}
                       </ul>
-                    </li>
-                    <li className="mt-auto">
-                      <a
-                        href="#"
-                        className="group -mx-2 flex gap-x-3 rounded-md p-2 text-sm/6 font-semibold text-gray-700 hover:bg-gray-50 hover:text-[#288dcf]"
-                      >
-                        <Cog6ToothIcon className="size-6 shrink-0 text-gray-400 group-hover:text-[#288dcf]" />
-                        Settings
-                      </a>
                     </li>
                   </ul>
                 </nav>
@@ -179,7 +168,7 @@ export default function InternalLayout({ children }) {
                     ))}
                   </ul>
                 </li>
-                <li>
+                <li className="mt-auto">
                   <div className="text-xs/6 font-semibold text-gray-400">Your teams</div>
                   <ul role="list" className="-mx-2 mt-2 space-y-1">
                     {teams.map((team) => (
@@ -208,15 +197,6 @@ export default function InternalLayout({ children }) {
                       </li>
                     ))}
                   </ul>
-                </li>
-                <li className="mt-auto">
-                  <a
-                    href="#"
-                    className="group -mx-2 flex gap-x-3 rounded-md p-2 text-sm/6 font-semibold text-gray-700 hover:bg-gray-50 hover:text-[#288dcf]"
-                  >
-                    <Cog6ToothIcon className="size-6 shrink-0 text-gray-400 group-hover:text-[#288dcf]" />
-                    Settings
-                  </a>
                 </li>
               </ul>
             </nav>

--- a/src/pages/Account.jsx
+++ b/src/pages/Account.jsx
@@ -4,7 +4,7 @@ import InternalLayout from '../layout/InternalLayout';
 export default function Account() {
   return (
     <InternalLayout>
-      <UserProfile />
+      <UserProfile routing="path" path="/account" />
     </InternalLayout>
   );
 }

--- a/src/pages/SignIn.jsx
+++ b/src/pages/SignIn.jsx
@@ -3,7 +3,7 @@ import { SignIn } from '@clerk/clerk-react';
 export default function SignInPage() {
   return (
     <div className="min-h-screen flex items-center justify-center">
-      <SignIn routing="path" path="/login" />
+      <SignIn routing="path" path="/login" afterSignInUrl="/dashboard" />
     </div>
   );
 }

--- a/src/pages/SignUp.jsx
+++ b/src/pages/SignUp.jsx
@@ -3,7 +3,7 @@ import { SignUp } from '@clerk/clerk-react';
 export default function SignUpPage() {
   return (
     <div className="min-h-screen flex items-center justify-center">
-      <SignUp routing="path" path="/sign-up" />
+      <SignUp routing="path" path="/sign-up" afterSignUpUrl="/dashboard" />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- ensure Clerk profile navigation uses internal routing
- redirect after sign-in/up to dashboard
- remove Settings item and pin Packages/Blogs/Support to sidebar footer

## Testing
- `npm test` *(fails: Missing script "test")*
- `VITE_CLERK_PUBLISHABLE_KEY=test npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a22558880832e8ccad413c5b6df6a