### PR TITLE
feat: add blog pages and components

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,6 +10,7 @@ import Account from './pages/Account';
 import TermsOfService from './pages/TermsOfService';
 import PrivacyPolicy from './pages/PrivacyPolicy';
 import Blogs from './pages/Blogs';
+import BlogPost from './pages/BlogPost';
 import About from './pages/About';
 import Press from './pages/Press';
 import Support from './pages/Support';
@@ -27,6 +28,7 @@ function App() {
         <Route path="/reports" element={<ProtectedRoute><Reports /></ProtectedRoute>} /> {/* ✅ Add this route */}
         <Route path="/account" element={<ProtectedRoute><Account /></ProtectedRoute>} />
         <Route path="/blogs" element={<Blogs />} />
+        <Route path="/blogs/:slug" element={<BlogPost />} />
         <Route path="/about" element={<About />} />
         <Route path="/press" element={<Press />} />
         <Route path="/support" element={<Support />} />

--- a/src/components/BlogCard.jsx
+++ b/src/components/BlogCard.jsx
@@ -1,0 +1,56 @@
+export default function BlogCard({ post }) {
+  return (
+    <article className="flex flex-col items-start justify-between">
+      <div className="relative w-full">
+        <img
+          alt={post.title}
+          src={post.imageUrl}
+          className="aspect-video w-full rounded-2xl bg-gray-100 object-cover sm:aspect-2/1 lg:aspect-3/2 dark:bg-gray-800"
+        />
+        <div className="absolute inset-0 rounded-2xl inset-ring inset-ring-gray-900/10 dark:inset-ring-white/10" />
+      </div>
+      <div className="flex max-w-xl grow flex-col justify-between">
+        <div className="mt-8 flex items-center gap-x-4 text-xs">
+          <time dateTime={post.datetime} className="text-gray-500 dark:text-gray-400">
+            {post.date}
+          </time>
+          <a
+            href={post.category.href}
+            className="relative z-10 rounded-full bg-gray-50 px-3 py-1.5 font-medium text-gray-600 hover:bg-gray-100 dark:bg-gray-800/60 dark:text-gray-300 dark:hover:bg-gray-800"
+          >
+            {post.category.title}
+          </a>
+        </div>
+        <div className="group relative grow">
+          <h3 className="mt-3 text-lg/6 font-semibold text-gray-900 group-hover:text-gray-600 dark:text-white dark:group-hover:text-gray-300">
+            <a href={post.href}>
+              <span className="absolute inset-0" />
+              {post.title}
+            </a>
+          </h3>
+          <p className="mt-5 line-clamp-3 text-sm/6 text-gray-600 dark:text-gray-400">{post.description}</p>
+        </div>
+        <div className="relative mt-8 flex items-center gap-x-4 justify-self-end">
+          {post.author.imageUrl && (
+            <img
+              alt=""
+              src={post.author.imageUrl}
+              className="size-10 rounded-full bg-gray-100 dark:bg-gray-800"
+            />
+          )}
+          <div className="text-sm/6">
+            <p className="font-semibold text-gray-900 dark:text-white">
+              <a href={post.author.href}>
+                <span className="absolute inset-0" />
+                {post.author.name}
+              </a>
+            </p>
+            {post.author.role && (
+              <p className="text-gray-600 dark:text-gray-400">{post.author.role}</p>
+            )}
+          </div>
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/src/components/BlogFlyer.jsx
+++ b/src/components/BlogFlyer.jsx
@@ -1,118 +1,24 @@
-const posts = [
-    {
-      id: 1,
-      title: 'How to Use Different Types of Digital Billboards',
-      href: '#',
-      description:
-        'Digital billboards are a powerful tool for advertising, but they come in various types. Understanding how to use each type effectively can maximize your advertising impact.',
-      imageUrl:'https://ik.imagekit.io/boardbid/Blog%20Creative%20city.webp',
-      date: 'Jul 21, 2025',
-      datetime: '2025-07-21',
-      category: { title: 'Marketing', href: '#' },
-      author: {
-        name: 'Jamie Rush',
-        role: '',
-        href: '#',
-        imageUrl:
-          '',
-      },
-    },
-    {
-      id: 2,
-      title: 'Advantages of Digital Out Of Home Advertising',
-      href: '#',
-      description: 'Digital Out Of Home (DOOH) advertising offers numerous advantages over traditional advertising methods. From real-time updates to targeted messaging, learn how DOOH can enhance your marketing strategy.',
-      imageUrl:'https://ik.imagekit.io/boardbid/adv%20creative.png',
-      date: 'Jul 28, 2025',
-      datetime: '2025-07-28',
-      category: { title: 'Marketing', href: '#' },
-      author: {
-        name: 'Kavya Mohana Adusumilli',
-        role: '',
-        href: '#',
-        imageUrl:
-          '',
-      },
-    },
-    {
-      id: 3,
-      title: 'Benefits of Programmatic DOOH Advertising',
-      href: '#',
-      description:
-        'Programmatic DOOH advertising revolutionizes how brands reach their audience. By automating the buying process, it allows for more efficient and targeted advertising campaigns.',
-      imageUrl:
-        'https://ik.imagekit.io/boardbid/p2.webp',
-      date: 'Aug 04, 2025',
-      datetime: '2025-08-04',
-      category: { title: 'Technology', href: '#' },
-      author: {
-        name: 'Sai Vara Prasad Avula',
-        role: '',
-        href: '#',
-        imageUrl:
-          '',
-      },
-    },
-  ]
-  
-  export default function Example() {
-    return (
-        <div className="bg-white pt-12 sm:pt-20 pb-24 sm:pb-32">
-        <div className="mx-auto max-w-7xl px-6 lg:px-8">
-          <div className="mx-auto max-w-2xl text-center">
-            <h2 className="text-4xl font-semibold tracking-tight text-balance text-gray-900 sm:text-5xl">
-              From the blog
-            </h2>
-            <p className="mt-2 text-lg/8 text-gray-600">Learn how to grow your business with our expert advice.</p>
-          </div>
-          <div className="mx-auto mt-16 grid max-w-2xl grid-cols-1 gap-x-8 gap-y-20 lg:mx-0 lg:max-w-none lg:grid-cols-3">
-            {posts.map((post) => (
-              <article key={post.id} className="flex flex-col items-start justify-between">
-                <div className="relative w-full">
-                  <img
-                    alt=""
-                    src={post.imageUrl}
-                    className="aspect-video w-full rounded-2xl bg-gray-100 object-cover sm:aspect-2/1 lg:aspect-3/2"
-                  />
-                  <div className="absolute inset-0 rounded-2xl inset-ring inset-ring-gray-900/10" />
-                </div>
-                <div className="flex max-w-xl grow flex-col justify-between">
-                  <div className="mt-8 flex items-center gap-x-4 text-xs">
-                    <time dateTime={post.datetime} className="text-gray-500">
-                      {post.date}
-                    </time>
-                    <a
-                      href={post.category.href}
-                      className="relative z-10 rounded-full bg-gray-50 px-3 py-1.5 font-medium text-gray-600 hover:bg-gray-100"
-                    >
-                      {post.category.title}
-                    </a>
-                  </div>
-                  <div className="group relative grow">
-                    <h3 className="mt-3 text-lg/6 font-semibold text-gray-900 group-hover:text-gray-600">
-                      <a href={post.href}>
-                        <span className="absolute inset-0" />
-                        {post.title}
-                      </a>
-                    </h3>
-                    <p className="mt-5 line-clamp-3 text-sm/6 text-gray-600">{post.description}</p>
-                  </div>
-                  <div className="relative mt-8 flex items-center gap-x-4 justify-self-end">
-                    <div className="text-sm/6">
-                      <p className="font-semibold text-gray-900">
-                        <a href={post.author.href}>
-                          <span className="absolute inset-0" />
-                          {post.author.name}
-                        </a>
-                      </p>
-                    </div>
-                  </div>
-                </div>
-              </article>
-            ))}
-          </div>
+import BlogCard from './BlogCard';
+import { posts as defaultPosts } from '../data/blogs';
+
+export default function BlogFlyer({ posts = defaultPosts }) {
+  return (
+    <div className="bg-white py-24 sm:py-32 dark:bg-gray-900">
+      <div className="mx-auto max-w-7xl px-6 lg:px-8">
+        <div className="mx-auto max-w-2xl text-center">
+          <h2 className="text-4xl font-semibold tracking-tight text-balance text-gray-900 sm:text-5xl dark:text-white">
+            From the blog
+          </h2>
+          <p className="mt-2 text-lg/8 text-gray-600 dark:text-gray-300">
+            Learn how to grow your business with our expert advice.
+          </p>
+        </div>
+        <div className="mx-auto mt-16 grid max-w-2xl grid-cols-1 gap-x-8 gap-y-20 lg:mx-0 lg:max-w-none lg:grid-cols-3">
+          {posts.map((post) => (
+            <BlogCard key={post.id} post={post} />
+          ))}
         </div>
       </div>
-    )
-  }
-  
+    </div>
+  );
+}

--- a/src/data/blogs.js
+++ b/src/data/blogs.js
@@ -1,0 +1,76 @@
+export const posts = [
+  {
+    id: 1,
+    slug: 'how-to-use-different-types-of-digital-billboards',
+    href: '/blogs/how-to-use-different-types-of-digital-billboards',
+    title: 'How to Use Different Types of Digital Billboards',
+    description:
+      'Digital billboards come in a variety of formats. Learn when to use street-level screens, highway displays and interactive kiosks to maximize your campaign.',
+    imageUrl: 'https://ik.imagekit.io/boardbid/Blog%20Creative%20city.webp',
+    date: 'Jul 21, 2025',
+    datetime: '2025-07-21',
+    category: { title: 'Marketing', href: '#' },
+    author: {
+      name: 'Jamie Rush',
+      role: 'Marketing Strategist',
+      href: '#',
+      imageUrl: '',
+    },
+    content: [
+      'Digital billboards are not a one-size-fits-all medium. Roadside screens deliver broad reach for brand awareness, while vibrant urban panels spark engagement with pedestrians. Understanding the strengths of each format helps you choose the right canvas for your message.',
+      'Large highway displays are perfect for introducing a product or reinforcing brand recognition. Their scale and visibility make them ideal for simple messages that drivers can absorb in seconds.',
+      'Street-level units, including bus shelters and storefront displays, cater to a slower audience. These screens let you share more detailed calls to action, like directions to a nearby store or a scannable QR code.',
+      'Interactive kiosks are gaining popularity in malls and transit hubs. These units invite people to engage directly with your content, providing valuable data while creating memorable experiences.',
+    ],
+  },
+  {
+    id: 2,
+    slug: 'advantages-of-digital-out-of-home-advertising',
+    href: '/blogs/advantages-of-digital-out-of-home-advertising',
+    title: 'Advantages of Digital Out Of Home Advertising',
+    description:
+      'Digital out of home (DOOH) brings the flexibility of online marketing to public spaces. Discover why more brands are shifting budget to dynamic screens.',
+    imageUrl: 'https://ik.imagekit.io/boardbid/adv%20creative.png',
+    date: 'Jul 28, 2025',
+    datetime: '2025-07-28',
+    category: { title: 'Marketing', href: '#' },
+    author: {
+      name: 'Kavya Mohana Adusumilli',
+      role: 'Content Writer',
+      href: '#',
+      imageUrl: '',
+    },
+    content: [
+      'DOOH campaigns can be updated in minutes, giving marketers the ability to tailor messages to time of day, weather or live events. This agility mirrors the responsiveness of digital display advertising while taking advantage of real-world visibility.',
+      'Because DOOH is seen in shared public spaces, it reaches audiences that may not be online. Screens placed in transit hubs, shopping centers and entertainment districts capture attention at moments when people are more receptive to new ideas.',
+      'Dynamic creative drives stronger recall than static posters. Motion and animation naturally draw the eye, helping brands stand out in crowded environments and making campaigns more memorable.',
+      'Modern DOOH networks also provide measurement tools, allowing advertisers to connect exposure with website visits or in-store traffic. This accountability makes it easier to justify spend and optimize performance.',
+    ],
+  },
+  {
+    id: 3,
+    slug: 'benefits-of-programmatic-dooh-advertising',
+    href: '/blogs/benefits-of-programmatic-dooh-advertising',
+    title: 'Benefits of Programmatic DOOH Advertising',
+    description:
+      'Automated buying is reshaping out of home media. Learn how programmatic platforms simplify campaigns and deliver data-driven results.',
+    imageUrl: 'https://ik.imagekit.io/boardbid/p2.webp',
+    date: 'Aug 04, 2025',
+    datetime: '2025-08-04',
+    category: { title: 'Technology', href: '#' },
+    author: {
+      name: 'Sai Vara Prasad Avula',
+      role: 'Product Director',
+      href: '#',
+      imageUrl: '',
+    },
+    content: [
+      'Programmatic DOOH automates the process of buying inventory across multiple networks, saving time for media planners. With a single dashboard, brands can launch campaigns in minutes rather than weeks.',
+      'Real-time bidding means you only pay for impressions that match your audience criteria. This precision reduces wasted spend and ensures your message appears in the most relevant locations.',
+      'Data feeds can trigger content based on live conditions. For example, a beverage brand might promote hot drinks on chilly mornings and switch to cold beverages as temperatures rise.',
+      'Programmatic platforms also provide detailed reporting, so marketers can analyze performance and adjust strategies quickly. This level of insight was once reserved for online ads but is now available in the physical world.',
+    ],
+  },
+];
+
+export default posts;

--- a/src/pages/BlogPost.jsx
+++ b/src/pages/BlogPost.jsx
@@ -1,0 +1,48 @@
+import { useParams } from 'react-router-dom';
+import { posts } from '../data/blogs';
+import Header from '../components/Header';
+import Footer from '../components/Footer';
+
+export default function BlogPost() {
+  const { slug } = useParams();
+  const post = posts.find((p) => p.slug === slug);
+
+  if (!post) {
+    return (
+      <>
+        <Header staticHeader />
+        <div className="mx-auto max-w-7xl px-6 py-24 text-center">
+          <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">Blog not found</h1>
+        </div>
+        <Footer />
+      </>
+    );
+  }
+
+  return (
+    <>
+      <Header staticHeader />
+      <article className="mx-auto max-w-3xl px-6 py-24 prose prose-lg dark:prose-invert">
+        <h1>{post.title}</h1>
+        <div className="mt-4 flex items-center gap-x-4 text-sm text-gray-600 dark:text-gray-400">
+          <time dateTime={post.datetime}>{post.date}</time>
+          <span>\u00B7</span>
+          <span>{post.author.name}</span>
+        </div>
+        {post.imageUrl && (
+          <img
+            src={post.imageUrl}
+            alt={post.title}
+            className="mt-8 w-full rounded-xl object-cover"
+          />
+        )}
+        {post.content.map((paragraph, idx) => (
+          <p key={idx} className="mt-8">
+            {paragraph}
+          </p>
+        ))}
+      </article>
+      <Footer />
+    </>
+  );
+}

--- a/src/pages/Blogs.jsx
+++ b/src/pages/Blogs.jsx
@@ -2,12 +2,13 @@ import React from 'react';
 import Header from '../components/Header';
 import Footer from '../components/Footer';
 import BlogFlyer from '../components/BlogFlyer';
+import { posts } from '../data/blogs';
 
 export default function Blogs() {
   return (
     <>
       <Header staticHeader />
-      <BlogFlyer />
+      <BlogFlyer posts={posts} />
       <Footer />
     </>
   );

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -7,6 +7,7 @@ import TargetLocations from '../components/TargetLocations';
 import WhyChoose from '../components/WhyChoose';
 import BlogFlyer from '../components/BlogFlyer';
 import Footer from '../components/Footer';
+import { posts } from '../data/blogs';
 
 export default function Home() {
   return (
@@ -17,7 +18,7 @@ export default function Home() {
       <Integrations />
       <TargetLocations />
       <WhyChoose />
-      <BlogFlyer />
+      <BlogFlyer posts={posts} />
       <Footer />
     </>
   );


### PR DESCRIPTION
## Summary
- add reusable blog card and blog listing components
- create data-driven blog posts and dynamic blog detail page
- wire up blog routes and show previews on home and blogs pages

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689a2f3da370832e9368e753541cd13c