### PR TITLE
Fix blog navigation under base URL

### DIFF
--- a/src/components/BlogCard.jsx
+++ b/src/components/BlogCard.jsx
@@ -1,3 +1,5 @@
+import { Link } from 'react-router-dom';
+
 export default function BlogCard({ post }) {
   return (
     <article className="flex flex-col items-start justify-between">
@@ -14,19 +16,19 @@ export default function BlogCard({ post }) {
           <time dateTime={post.datetime} className="text-gray-500 dark:text-gray-400">
             {post.date}
           </time>
-          <a
-            href={post.category.href}
+          <Link
+            to={post.category.href}
             className="relative z-10 rounded-full bg-gray-50 px-3 py-1.5 font-medium text-gray-600 hover:bg-gray-100 dark:bg-gray-800/60 dark:text-gray-300 dark:hover:bg-gray-800"
           >
             {post.category.title}
-          </a>
+          </Link>
         </div>
         <div className="group relative grow">
           <h3 className="mt-3 text-lg/6 font-semibold text-gray-900 group-hover:text-gray-600 dark:text-white dark:group-hover:text-gray-300">
-            <a href={post.href}>
+            <Link to={post.href}>
               <span className="absolute inset-0" />
               {post.title}
-            </a>
+            </Link>
           </h3>
           <p className="mt-5 line-clamp-3 text-sm/6 text-gray-600 dark:text-gray-400">{post.description}</p>
         </div>
@@ -40,10 +42,10 @@ export default function BlogCard({ post }) {
           )}
           <div className="text-sm/6">
             <p className="font-semibold text-gray-900 dark:text-white">
-              <a href={post.author.href}>
+              <Link to={post.author.href}>
                 <span className="absolute inset-0" />
                 {post.author.name}
-              </a>
+              </Link>
             </p>
             {post.author.role && (
               <p className="text-gray-600 dark:text-gray-400">{post.author.role}</p>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -44,7 +44,7 @@ export default function Header({ staticHeader = false }) {
       id="sticky-header"
       className="fixed top-0 left-0 right-0 w-full h-20 bg-white/90 backdrop-blur z-50 shadow-md px-6 flex justify-between items-center transform -translate-y-4 opacity-0 pointer-events-none transition-all duration-500"
     >
-      <Link to="/dashboard" className="flex items-center">
+      <Link to="/" className="flex items-center">
         <img
           src="https://ik.imagekit.io/boardbid/BoardBid%20logo.svg"
           alt="BoardBid Logo"


### PR DESCRIPTION
## Summary
- Use React Router `Link` for blog cards so internal URLs respect the `/boardbid-ui` base path
- Point header logo back to home for simpler navigation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a3849d750832e967e40cb3779bf0c