### PR TITLE
Scale down dashboard greeting and adjust sidebar spacing

### DIFF
--- a/src/layout/InternalLayout.jsx
+++ b/src/layout/InternalLayout.jsx
@@ -56,7 +56,7 @@ export default function InternalLayout({ children }) {
                 </div>
               </TransitionChild>
 
-              <div className="flex grow flex-col gap-y-5 overflow-y-auto bg-white px-6 pb-4">
+              <div className="flex grow flex-col gap-y-8 overflow-y-auto bg-white px-6 pb-4">
                 <div className="flex h-16 shrink-0 items-center">
                   <img
                     alt="Boardbid Logo"
@@ -131,7 +131,7 @@ export default function InternalLayout({ children }) {
         </Dialog>
 
         <div className="hidden lg:fixed lg:inset-y-0 lg:z-50 lg:flex lg:w-72 lg:flex-col">
-          <div className="flex grow flex-col gap-y-5 overflow-y-auto bg-white px-6 pb-4 border-r border-gray-200">
+          <div className="flex grow flex-col gap-y-8 overflow-y-auto bg-white px-6 pb-4 border-r border-gray-200">
             <div className="flex h-16 shrink-0 items-center">
               <img
                 alt="Boardbid Logo"

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -4,7 +4,9 @@ import WelcomeBack from '../components/WelcomeBack';
 export default function Dashboard() {
   return (
     <InternalLayout>
-      <WelcomeBack />
+      <div className="scale-50 origin-top-left w-fit">
+        <WelcomeBack />
+      </div>
     </InternalLayout>
   );
 }


### PR DESCRIPTION
## Summary
- Scale WelcomeBack card to half size on dashboard
- Increase sidebar top spacing so menu items sit lower

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689ada465cd8832e9a07261780e211c3