### PR TITLE
fix: use base URL for Clerk redirects

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -16,10 +16,10 @@ function ClerkApp() {
     <ClerkProvider
       publishableKey={PUBLISHABLE_KEY}
       navigate={(to) => navigate(to)}
-      signInUrl="/login"
-      signUpUrl="/sign-up"
-      userProfileUrl="/account"
-      afterSignOutUrl="/"
+      signInUrl={`${import.meta.env.BASE_URL}login`}
+      signUpUrl={`${import.meta.env.BASE_URL}sign-up`}
+      userProfileUrl={`${import.meta.env.BASE_URL}account`}
+      afterSignOutUrl={import.meta.env.BASE_URL}
     >
       <App />
     </ClerkProvider>


### PR DESCRIPTION
## Summary
- ensure Clerk redirect URLs respect public base path

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_689af31c6590832e9e9d42ae233f7785