### PR TITLE
fix: adjust base path for local dev

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -28,7 +28,7 @@ function ClerkApp() {
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <BrowserRouter basename="/boardbid-ui">
+    <BrowserRouter basename={import.meta.env.BASE_URL.replace(/\/$/, '')}>
       <ClerkApp />
     </BrowserRouter>
   </StrictMode>,

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,9 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
-export default defineConfig({
-  base: '/boardbid-ui/', // 👈 VERY IMPORTANT
+export default defineConfig(({ command }) => ({
+  // Use a subdirectory base when building for production (e.g. GitHub Pages)
+  // but fall back to root during local development to avoid redirect issues.
+  base: command === 'serve' ? '/' : '/boardbid-ui/',
   plugins: [react()],
-});
+}));


### PR DESCRIPTION
## Summary
- configure vite base to use root in dev, subdir in production
- derive router basename from Vite base URL

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689af7e63614832e96663a285eb3265c