### PR TITLE
feat: add campaigns pages with navigation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,7 +5,8 @@ import SignUpPage from './pages/SignUp';
 import Dashboard from './pages/Dashboard';
 import NewCampaignPage from './pages/NewCampaignPage';
 import UploadCreative from './pages/UploadCreative';
-import Reports from './pages/Reports';
+import Campaigns from './pages/Campaigns';
+import CampaignDetail from './pages/CampaignDetail';
 import Account from './pages/Account';
 import TermsOfService from './pages/TermsOfService';
 import PrivacyPolicy from './pages/PrivacyPolicy';
@@ -25,7 +26,8 @@ function App() {
         <Route path="/dashboard" element={<ProtectedRoute><Dashboard /></ProtectedRoute>} />
         <Route path="/campaign/new" element={<ProtectedRoute><NewCampaignPage /></ProtectedRoute>} />
         <Route path="/upload-creative" element={<ProtectedRoute><UploadCreative /></ProtectedRoute>} />
-        <Route path="/reports" element={<ProtectedRoute><Reports /></ProtectedRoute>} /> {/* ✅ Add this route */}
+        <Route path="/campaigns" element={<ProtectedRoute><Campaigns /></ProtectedRoute>} />
+        <Route path="/campaigns/:id/*" element={<ProtectedRoute><CampaignDetail /></ProtectedRoute>} />
         <Route path="/account/*" element={<ProtectedRoute><Account /></ProtectedRoute>} />
         <Route path="/blogs" element={<Blogs />} />
         <Route path="/blogs/:slug" element={<BlogPost />} />

--- a/src/layout/InternalLayout.jsx
+++ b/src/layout/InternalLayout.jsx
@@ -11,11 +11,11 @@ import {
 import {
   Bars3Icon,
   BellIcon,
-  ChartPieIcon,
   DocumentDuplicateIcon,
   FolderIcon,
   HomeIcon,
   XMarkIcon,
+  ClipboardDocumentListIcon,
 } from '@heroicons/react/24/outline';
 import { UserButton } from '@clerk/clerk-react';
 
@@ -23,7 +23,7 @@ const navigation = [
   { name: 'Dashboard', href: '/dashboard', icon: HomeIcon },
   { name: 'Upload Creative', href: '/upload-creative', icon: DocumentDuplicateIcon },
   { name: 'New Campaign', href: '/campaign/new', icon: FolderIcon },
-  { name: 'Reports', href: '/reports', icon: ChartPieIcon },
+  { name: 'My Campaigns', href: '/campaigns', icon: ClipboardDocumentListIcon },
 ];
 
 const teams = [

--- a/src/pages/CampaignCreative.jsx
+++ b/src/pages/CampaignCreative.jsx
@@ -1,0 +1,3 @@
+export default function CampaignCreative() {
+  return <div className="text-gray-500">Creative content coming soon.</div>;
+}

--- a/src/pages/CampaignDetail.jsx
+++ b/src/pages/CampaignDetail.jsx
@@ -1,0 +1,54 @@
+import InternalLayout from '../layout/InternalLayout';
+import { NavLink, Routes, Route, Navigate } from 'react-router-dom';
+import CampaignCreative from './CampaignCreative';
+import CampaignProgress from './CampaignProgress';
+import CampaignReports from './CampaignReports';
+
+function classNames(...classes) {
+  return classes.filter(Boolean).join(' ');
+}
+
+export default function CampaignDetail() {
+  const navigation = [
+    { name: 'Creative', to: 'creative' },
+    { name: 'View Campaign Progress', to: 'progress' },
+    { name: 'Reports', to: 'reports' },
+  ];
+
+  return (
+    <InternalLayout>
+      <div className="min-h-full">
+        <nav className="border-b border-gray-200 bg-white">
+          <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+            <div className="flex h-16 space-x-8">
+              {navigation.map((item) => (
+                <NavLink
+                  key={item.name}
+                  to={item.to}
+                  className={({ isActive }) =>
+                    classNames(
+                      isActive
+                        ? 'border-[#288dcf] text-gray-900'
+                        : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700',
+                      'inline-flex items-center border-b-2 px-1 pt-1 text-sm font-medium'
+                    )
+                  }
+                >
+                  {item.name}
+                </NavLink>
+              ))}
+            </div>
+          </div>
+        </nav>
+        <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+          <Routes>
+            <Route path="creative" element={<CampaignCreative />} />
+            <Route path="progress" element={<CampaignProgress />} />
+            <Route path="reports" element={<CampaignReports />} />
+            <Route index element={<Navigate to="creative" replace />} />
+          </Routes>
+        </div>
+      </div>
+    </InternalLayout>
+  );
+}

--- a/src/pages/CampaignProgress.jsx
+++ b/src/pages/CampaignProgress.jsx
@@ -1,0 +1,3 @@
+export default function CampaignProgress() {
+  return <div className="text-gray-500">Campaign progress will appear here.</div>;
+}

--- a/src/pages/CampaignReports.jsx
+++ b/src/pages/CampaignReports.jsx
@@ -1,0 +1,3 @@
+export default function CampaignReports() {
+  return <div className="text-gray-500">Reports coming soon.</div>;
+}

--- a/src/pages/Campaigns.jsx
+++ b/src/pages/Campaigns.jsx
@@ -1,0 +1,109 @@
+import InternalLayout from '../layout/InternalLayout';
+import { Menu, MenuButton, MenuItem, MenuItems } from '@headlessui/react';
+import { EllipsisHorizontalIcon } from '@heroicons/react/20/solid';
+import { useNavigate } from 'react-router-dom';
+
+const clients = [
+  {
+    id: 1,
+    name: 'Tuple',
+    imageUrl: 'https://tailwindcss.com/plus-assets/img/logos/48x48/tuple.svg',
+    lastInvoice: { date: 'December 13, 2022', dateTime: '2022-12-13', amount: '$2,000.00', status: 'Overdue' },
+  },
+  {
+    id: 2,
+    name: 'SavvyCal',
+    imageUrl: 'https://tailwindcss.com/plus-assets/img/logos/48x48/savvycal.svg',
+    lastInvoice: { date: 'January 22, 2023', dateTime: '2023-01-22', amount: '$14,000.00', status: 'Paid' },
+  },
+  {
+    id: 3,
+    name: 'Reform',
+    imageUrl: 'https://tailwindcss.com/plus-assets/img/logos/48x48/reform.svg',
+    lastInvoice: { date: 'January 23, 2023', dateTime: '2023-01-23', amount: '$7,600.00', status: 'Paid' },
+  },
+];
+
+export default function Campaigns() {
+  const navigate = useNavigate();
+
+  return (
+    <InternalLayout>
+      <ul role="list" className="grid grid-cols-1 gap-x-6 gap-y-8 lg:grid-cols-3 xl:gap-x-8">
+        {clients.map((client) => (
+          <li
+            key={client.id}
+            onClick={() => navigate(`/campaigns/${client.id}`)}
+            className="overflow-hidden rounded-xl outline outline-gray-200 cursor-pointer dark:-outline-offset-1 dark:outline-white/10"
+          >
+            <div className="flex items-center gap-x-4 border-b border-gray-900/5 bg-gray-50 p-6 dark:border-white/10 dark:bg-gray-800/50">
+              <img
+                alt={client.name}
+                src={client.imageUrl}
+                className="size-12 flex-none rounded-lg bg-white object-cover ring-1 ring-gray-900/10 dark:bg-gray-700 dark:ring-white/10"
+              />
+              <div className="text-sm/6 font-medium text-gray-900 dark:text-white">{client.name}</div>
+              <Menu as="div" className="relative ml-auto" onClick={(e) => e.stopPropagation()}>
+                <MenuButton className="relative block text-gray-400 hover:text-gray-500 dark:text-gray-400 dark:hover:text-white">
+                  <span className="absolute -inset-2.5" />
+                  <span className="sr-only">Open options</span>
+                  <EllipsisHorizontalIcon aria-hidden="true" className="size-5" />
+                </MenuButton>
+                <MenuItems
+                  transition
+                  className="absolute right-0 z-10 mt-0.5 w-32 origin-top-right rounded-md bg-white py-2 shadow-lg outline-1 outline-gray-900/5 transition data-closed:scale-95 data-closed:transform data-closed:opacity-0 data-enter:duration-100 data-enter:ease-out data-leave:duration-75 data-leave:ease-in dark:bg-gray-800 dark:shadow-none dark:-outline-offset-1 dark:outline-white/10"
+                >
+                  <MenuItem>
+                    <a
+                      href="#"
+                      className="block px-3 py-1 text-sm/6 text-gray-900 data-focus:bg-gray-50 data-focus:outline-hidden dark:text-white dark:data-focus:bg-white/5"
+                    >
+                      View<span className="sr-only">, {client.name}</span>
+                    </a>
+                  </MenuItem>
+                  <MenuItem>
+                    <a
+                      href="#"
+                      className="block px-3 py-1 text-sm/6 text-gray-900 data-focus:bg-gray-50 data-focus:outline-hidden dark:text-white dark:data-focus:bg-white/5"
+                    >
+                      Edit<span className="sr-only">, {client.name}</span>
+                    </a>
+                  </MenuItem>
+                </MenuItems>
+              </Menu>
+            </div>
+            <dl className="-my-3 divide-y divide-gray-100 px-6 py-4 text-sm/6 dark:divide-white/10">
+              <div className="flex justify-between gap-x-4 py-3">
+                <dt className="text-gray-500 dark:text-gray-400">Last invoice</dt>
+                <dd className="text-gray-700 dark:text-gray-300">
+                  <time dateTime={client.lastInvoice.dateTime}>{client.lastInvoice.date}</time>
+                </dd>
+              </div>
+              <div className="flex justify-between gap-x-4 py-3">
+                <dt className="text-gray-500 dark:text-gray-400">Amount</dt>
+                <dd className="flex items-start gap-x-2">
+                  <div className="font-medium text-gray-900 dark:text-white">{client.lastInvoice.amount}</div>
+                  {client.lastInvoice.status == 'Paid' ? (
+                    <div className="rounded-md bg-green-50 px-2 py-1 text-xs font-medium text-green-700 ring-1 ring-green-600/20 ring-inset dark:bg-green-500/10 dark:text-green-500 dark:ring-green-500/10">
+                      {client.lastInvoice.status}
+                    </div>
+                  ) : null}
+                  {client.lastInvoice.status == 'Withdraw' ? (
+                    <div className="rounded-md bg-gray-50 px-2 py-1 text-xs font-medium text-gray-600 ring-1 ring-gray-500/10 ring-inset dark:bg-white/5 dark:text-gray-400 dark:ring-white/10">
+                      {client.lastInvoice.status}
+                    </div>
+                  ) : null}
+                  {client.lastInvoice.status == 'Overdue' ? (
+                    <div className="rounded-md bg-red-50 px-2 py-1 text-xs font-medium text-red-700 ring-1 ring-red-600/10 ring-inset dark:bg-red-500/10 dark:text-red-400 dark:ring-red-500/10">
+                      {client.lastInvoice.status}
+                    </div>
+                  ) : null}
+                </dd>
+              </div>
+            </dl>
+          </li>
+        ))}
+      </ul>
+    </InternalLayout>
+  );
+}


### PR DESCRIPTION
## Summary
- add "My Campaigns" item in sidebar and remove reports
- create campaigns list page and campaign detail with tabbed navigation
- wire up routes for campaign views and placeholder subpages

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689aff6b83bc832eb7a8e24e8f8eacca