### PR TITLE
Fix campaign detail navigation

### DIFF
--- a/src/pages/CampaignDetail.jsx
+++ b/src/pages/CampaignDetail.jsx
@@ -1,5 +1,5 @@
 import InternalLayout from '../layout/InternalLayout';
-import { NavLink, Routes, Route, Navigate } from 'react-router-dom';
+import { NavLink, Routes, Route, Navigate, useParams } from 'react-router-dom';
 import CampaignCreative from './CampaignCreative';
 import CampaignProgress from './CampaignProgress';
 import CampaignReports from './CampaignReports';
@@ -9,6 +9,7 @@ function classNames(...classes) {
 }
 
 export default function CampaignDetail() {
+  const { id } = useParams();
   const navigation = [
     { name: 'Creative', to: 'creative' },
     { name: 'View Campaign Progress', to: 'progress' },
@@ -18,19 +19,19 @@ export default function CampaignDetail() {
   return (
     <InternalLayout>
       <div className="min-h-full">
-        <nav className="border-b border-gray-200 bg-white">
-          <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-            <div className="flex h-16 space-x-8">
+        <nav className="border-b border-indigo-300/25 bg-indigo-600">
+          <div className="mx-auto max-w-7xl px-2 sm:px-4 lg:px-8">
+            <div className="flex h-16 items-center space-x-4">
               {navigation.map((item) => (
                 <NavLink
                   key={item.name}
-                  to={item.to}
+                  to={`/campaigns/${id}/${item.to}`}
                   className={({ isActive }) =>
                     classNames(
                       isActive
-                        ? 'border-[#288dcf] text-gray-900'
-                        : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700',
-                      'inline-flex items-center border-b-2 px-1 pt-1 text-sm font-medium'
+                        ? 'bg-indigo-700 text-white'
+                        : 'text-white hover:bg-indigo-500/75',
+                      'rounded-md px-3 py-2 text-sm font-medium'
                     )
                   }
                 >
@@ -45,7 +46,7 @@ export default function CampaignDetail() {
             <Route path="creative" element={<CampaignCreative />} />
             <Route path="progress" element={<CampaignProgress />} />
             <Route path="reports" element={<CampaignReports />} />
-            <Route index element={<Navigate to="creative" replace />} />
+            <Route index element={<Navigate to={`/campaigns/${id}/creative`} replace />} />
           </Routes>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- prevent campaign detail tabs from appending duplicate path segments by linking with absolute paths
- restyle campaign detail navigation using indigo theme

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689b02f319b8832eb8788c6fc85e1cd6