### PR TITLE
feat: add reusable campaign card component

### DIFF
--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -1,0 +1,10 @@
+import CardHeader from './CardHeader';
+
+export default function Card({ title, children }) {
+  return (
+    <div className="divide-y divide-gray-200 overflow-hidden rounded-lg bg-white shadow-sm dark:divide-white/10 dark:bg-gray-800/50 dark:shadow-none dark:outline dark:-outline-offset-1 dark:outline-white/10">
+      {title && <CardHeader>{title}</CardHeader>}
+      <div className="px-4 py-5 sm:p-6">{children}</div>
+    </div>
+  );
+}

--- a/src/components/CardHeader.jsx
+++ b/src/components/CardHeader.jsx
@@ -1,0 +1,7 @@
+export default function CardHeader({ children }) {
+  return (
+    <div className="border-b border-gray-200 px-4 py-5 sm:px-6 dark:border-white/10">
+      <h3 className="text-base font-semibold text-gray-900 dark:text-white">{children}</h3>
+    </div>
+  );
+}

--- a/src/pages/CampaignCreative.jsx
+++ b/src/pages/CampaignCreative.jsx
@@ -1,3 +1,9 @@
+import Card from '../components/Card';
+
 export default function CampaignCreative() {
-  return <div className="text-gray-500">Creative content coming soon.</div>;
+  return (
+    <Card title="Heading to come">
+      <div className="text-gray-500">Creative content coming soon.</div>
+    </Card>
+  );
 }

--- a/src/pages/CampaignProgress.jsx
+++ b/src/pages/CampaignProgress.jsx
@@ -1,3 +1,9 @@
+import Card from '../components/Card';
+
 export default function CampaignProgress() {
-  return <div className="text-gray-500">Campaign progress will appear here.</div>;
+  return (
+    <Card title="Heading to come">
+      <div className="text-gray-500">Campaign progress will appear here.</div>
+    </Card>
+  );
 }

--- a/src/pages/CampaignReports.jsx
+++ b/src/pages/CampaignReports.jsx
@@ -1,3 +1,9 @@
+import Card from '../components/Card';
+
 export default function CampaignReports() {
-  return <div className="text-gray-500">Reports coming soon.</div>;
+  return (
+    <Card title="Heading to come">
+      <div className="text-gray-500">Reports coming soon.</div>
+    </Card>
+  );
 }


### PR DESCRIPTION
## Summary
- add reusable Card and CardHeader components
- display campaign sections within the new card

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689b062d1498832ea19d5f1f40701ac4