### PR TITLE
feat: add section headings to creative viewer

### DIFF
--- a/src/pages/CampaignCreative.jsx
+++ b/src/pages/CampaignCreative.jsx
@@ -2,8 +2,18 @@ import Card from '../components/Card';
 
 export default function CampaignCreative() {
   return (
-    <Card title="Heading to come">
-      <div className="text-gray-500">Creative content coming soon.</div>
-    </Card>
+    <div className="space-y-6">
+      <Card title="Creative Preview">
+        <div className="text-gray-500">Preview coming soon.</div>
+      </Card>
+
+      <Card title="Creative Details">
+        <div className="text-gray-500">Details coming soon.</div>
+      </Card>
+
+      <Card title="Performance">
+        <div className="text-gray-500">Metrics coming soon.</div>
+      </Card>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- structure creative viewer with separate sections for preview, details, and performance

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b096baeb4832eb35fe1ef53c37304