### PR TITLE
Add page headers to campaign pages

### DIFF
--- a/src/pages/Campaigns.jsx
+++ b/src/pages/Campaigns.jsx
@@ -1,4 +1,5 @@
 import InternalLayout from '../layout/InternalLayout';
+import PageHeader from '../components/PageHeader';
 import { Menu, MenuButton, MenuItem, MenuItems } from '@headlessui/react';
 import { EllipsisHorizontalIcon } from '@heroicons/react/20/solid';
 import { useNavigate } from 'react-router-dom';
@@ -29,6 +30,7 @@ export default function Campaigns() {
 
   return (
     <InternalLayout>
+      <PageHeader title="My Campaigns" />
       <ul role="list" className="grid grid-cols-1 gap-x-6 gap-y-8 lg:grid-cols-3 xl:gap-x-8">
         {clients.map((client) => (
           <li

--- a/src/pages/NewCampaignPage.jsx
+++ b/src/pages/NewCampaignPage.jsx
@@ -1,8 +1,10 @@
 import InternalLayout from "../layout/InternalLayout";
+import PageHeader from "../components/PageHeader";
 
 export default function NewCampaignPage() {
   return (
     <InternalLayout>
+      <PageHeader title="New Campaign" />
       <div className="w-full px-0 py-10">
         <iframe
           className="w-full h-[1000px]"

--- a/src/pages/UploadCreative.jsx
+++ b/src/pages/UploadCreative.jsx
@@ -1,6 +1,7 @@
 // ✅ src/pages/UploadCreative.jsx (with InternalLayout)
 import React, { useState } from 'react';
 import InternalLayout from '../layout/InternalLayout';
+import PageHeader from '../components/PageHeader';
 import Card from '../components/Card';
 import { validateCreative } from '../utils/validateCreative';
 import { db } from '../utils/db';
@@ -107,6 +108,7 @@ export default function UploadCreative() {
 
   return (
     <InternalLayout>
+      <PageHeader title="Upload Creative" />
       <Card title="🎨 Upload & Validate Creative">
         <label className="block mb-4 text-sm font-medium text-gray-700">
           Select a creative (jpg, png, or mp4)


### PR DESCRIPTION
## Summary
- add `PageHeader` to Upload Creative page
- add `PageHeader` to New Campaign page
- add `PageHeader` to My Campaigns page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b2536ce44832e85db67e27d53c0f8