### PR TITLE
Add contact page with Fillout form and navigation links

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,6 +15,7 @@ import BlogPost from './pages/BlogPost';
 import About from './pages/About';
 import Press from './pages/Press';
 import Support from './pages/Support';
+import Contact from './pages/Contact';
 import ProtectedRoute from './components/ProtectedRoute';
 
 function App() {
@@ -34,6 +35,7 @@ function App() {
         <Route path="/about" element={<About />} />
         <Route path="/press" element={<Press />} />
         <Route path="/support" element={<Support />} />
+        <Route path="/contact" element={<Contact />} />
         <Route path="/terms" element={<TermsOfService />} />
         <Route path="/privacy" element={<PrivacyPolicy />} />
     </Routes>

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -3,11 +3,15 @@ import { SignUpButton } from '@clerk/clerk-react';
 import { Link } from 'react-router-dom';
 
 const navigation = {
-  support: [{ name: 'Submit ticket', href: '/support' }],
+  support: [
+    { name: 'Submit ticket', href: '/support' },
+    { name: 'Contact', href: '/contact' },
+  ],
   company: [
     { name: 'About', href: '/about' },
     { name: 'Blogs', href: '/blogs' },
     { name: 'Press', href: '/press' },
+    { name: 'Contact', href: '/contact' },
   ],
   legal: [
     { name: 'Terms of Service', href: '/terms' },

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -54,6 +54,7 @@ export default function Header({ staticHeader = false }) {
 
       <nav className="space-x-6 text-sm font-semibold text-gray-700">
         <Link to="/blogs" className="hover:text-emerald-600 transition">Blog</Link>
+        <Link to="/contact" className="hover:text-emerald-600 transition">Contact</Link>
         <SignedOut>
           <SignInButton mode="modal" afterSignInUrl="/dashboard">
             <button className="hover:text-emerald-600 transition">Login</button>

--- a/src/components/HeroSection.jsx
+++ b/src/components/HeroSection.jsx
@@ -9,7 +9,7 @@ import { SignedIn, SignedOut, SignInButton, SignUpButton } from '@clerk/clerk-re
   const navigation = [
     { name: 'Product', href: '#' },
     { name: 'Pricing', href: '#' },
-    { name: 'Contact', href: '#' },
+    { name: 'Contact', href: '/contact' },
   ]
 
 export default function Hero() {

--- a/src/layout/InternalLayout.jsx
+++ b/src/layout/InternalLayout.jsx
@@ -29,7 +29,7 @@ const navigation = [
 const teams = [
   { id: 1, name: 'Packages', href: '#', initial: 'P', current: false },
   { id: 2, name: 'Blogs', href: '#', initial: 'B', current: false },
-  { id: 3, name: 'Support', href: '#', initial: 'S', current: false },
+  { id: 3, name: 'Support', href: '/contact', initial: 'S', current: false },
 ];
 
 function classNames(...classes) {

--- a/src/pages/Contact.jsx
+++ b/src/pages/Contact.jsx
@@ -1,0 +1,114 @@
+import Header from '../components/Header';
+import Footer from '../components/Footer';
+import Card from '../components/Card';
+import { BuildingOffice2Icon, EnvelopeIcon, PhoneIcon } from '@heroicons/react/24/outline';
+
+export default function Contact() {
+  return (
+    <>
+      <Header staticHeader />
+      <div className="relative isolate bg-white">
+        <div className="mx-auto grid max-w-7xl grid-cols-1 lg:grid-cols-2">
+          <div className="relative px-6 pt-24 pb-20 sm:pt-32 lg:static lg:px-8 lg:py-48">
+            <div className="mx-auto max-w-xl lg:mx-0 lg:max-w-lg">
+              <div className="absolute inset-y-0 left-0 -z-10 w-full overflow-hidden bg-gray-100 ring-1 ring-gray-900/10 lg:w-1/2">
+                <svg
+                  aria-hidden="true"
+                  className="absolute inset-0 size-full mask-[radial-gradient(100%_100%_at_top_right,white,transparent)] stroke-gray-200"
+                >
+                  <defs>
+                    <pattern
+                      x="100%"
+                      y={-1}
+                      id="contact-pattern"
+                      width={200}
+                      height={200}
+                      patternUnits="userSpaceOnUse"
+                    >
+                      <path d="M130 200V.5M.5 .5H200" fill="none" />
+                    </pattern>
+                  </defs>
+                  <rect width="100%" height="100%" strokeWidth={0} className="fill-white" />
+                  <svg x="100%" y={-1} className="overflow-visible fill-gray-50">
+                    <path d="M-470.5 0h201v201h-201Z" strokeWidth={0} />
+                  </svg>
+                  <rect fill="url(#contact-pattern)" width="100%" height="100%" strokeWidth={0} />
+                </svg>
+                <div
+                  aria-hidden="true"
+                  className="absolute top-[calc(100%-13rem)] -left-56 hidden transform-gpu blur-3xl lg:top-[calc(50%-7rem)] lg:left-[max(-14rem,calc(100%-59rem))]"
+                >
+                  <div
+                    style={{
+                      clipPath:
+                        'polygon(74.1% 56.1%, 100% 38.6%, 97.5% 73.3%, 85.5% 100%, 80.7% 98.2%, 72.5% 67.7%, 60.2% 37.8%, 52.4% 32.2%, 47.5% 41.9%, 45.2% 65.8%, 27.5% 23.5%, 0.1% 35.4%, 17.9% 0.1%, 27.6% 23.5%, 76.1% 2.6%, 74.1% 56.1%)',
+                    }}
+                    className="aspect-1155/678 w-288.75 bg-linear-to-br from-[#80caff] to-[#4f46e5] opacity-10"
+                  />
+                </div>
+              </div>
+              <h2 className="text-4xl font-semibold tracking-tight text-pretty text-gray-900 sm:text-5xl">
+                Get in touch
+              </h2>
+              <p className="mt-6 text-lg/8 text-gray-600">
+                Proin volutpat consequat porttitor cras nullam gravida at. Orci molestie a eu arcu. Sed ut tincidunt
+                integer elementum id sem. Arcu sed malesuada et magna.
+              </p>
+              <dl className="mt-10 space-y-4 text-base/7 text-gray-600">
+                <div className="flex gap-x-4">
+                  <dt className="flex-none">
+                    <span className="sr-only">Address</span>
+                    <BuildingOffice2Icon aria-hidden="true" className="h-7 w-6 text-gray-400" />
+                  </dt>
+                  <dd>
+                    545 Mavis Island
+                    <br />
+                    Chicago, IL 99191
+                  </dd>
+                </div>
+                <div className="flex gap-x-4">
+                  <dt className="flex-none">
+                    <span className="sr-only">Telephone</span>
+                    <PhoneIcon aria-hidden="true" className="h-7 w-6 text-gray-400" />
+                  </dt>
+                  <dd>
+                    <a href="tel:+1 (555) 234-5678" className="hover:text-gray-900">
+                      +1 (555) 234-5678
+                    </a>
+                  </dd>
+                </div>
+                <div className="flex gap-x-4">
+                  <dt className="flex-none">
+                    <span className="sr-only">Email</span>
+                    <EnvelopeIcon aria-hidden="true" className="h-7 w-6 text-gray-400" />
+                  </dt>
+                  <dd>
+                    <a href="mailto:hello@example.com" className="hover:text-gray-900">
+                      hello@example.com
+                    </a>
+                  </dd>
+                </div>
+              </dl>
+            </div>
+          </div>
+          <div className="px-6 pt-20 pb-24 sm:pb-32 lg:px-8 lg:py-48">
+            <div className="mx-auto max-w-xl lg:mr-0 lg:max-w-lg">
+              <Card title="Send us a message">
+                <div className="h-[600px]">
+                  <iframe
+                    title="Contact form"
+                    src="https://app.fillout.com/t/boardbid-contact"
+                    className="h-full w-full border-0"
+                    loading="lazy"
+                  />
+                </div>
+              </Card>
+            </div>
+          </div>
+        </div>
+      </div>
+      <Footer />
+    </>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add Contact page with embedded Fillout form inside Card
- wire up /contact route and navigation links across header, hero, footer, and internal layout

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b603b7e44832e8df8f19ffdbdac51