### PR TITLE
Load Clerk JS from CDN in dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # boardbid-ui
+
+Static site for BoardBid.
+
+## Development
+
+Clerk is loaded conditionally in `login.html` so the app works in both development and production. When running on `localhost` the Clerk JS library loads from the public CDN; otherwise the production custom domain `clerk.boardbid.ai` is used.

--- a/login.html
+++ b/login.html
@@ -35,6 +35,18 @@
       gtag('js', new Date());
       gtag('config', 'G-VBRL1YQ0QH');
     </script>
+    <script>
+      (function() {
+        const isLocal = ['localhost', '127.0.0.1'].includes(window.location.hostname);
+        const script = document.createElement('script');
+        script.src = isLocal
+          ? 'https://cdn.jsdelivr.net/npm/@clerk/clerk-js@latest/dist/clerk.browser.js'
+          : 'https://clerk.boardbid.ai/npm/@clerk/clerk-js@5/dist/clerk.browser.js';
+        script.async = true;
+        script.crossOrigin = 'anonymous';
+        document.head.appendChild(script);
+      })();
+    </script>
   </head>
   <body class="bg-gray-100 min-h-screen flex items-center justify-center px-4">
     <div class="bg-white shadow-xl rounded-xl p-8 sm:p-10 max-w-md w-full animate-fadeIn">


### PR DESCRIPTION
## Summary
- Load Clerk JS from Clerk CDN when running on localhost
- Document conditional Clerk loading

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b9b569d80832ebd7c195ec8963c04