### PR TITLE
Use React Router Link in HeroSection navigation

### DIFF
--- a/src/components/HeroSection.jsx
+++ b/src/components/HeroSection.jsx
@@ -7,9 +7,9 @@ import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/outline'
 import { SignedIn, SignedOut, SignInButton, SignUpButton } from '@clerk/clerk-react'
 
 const navigation = [
-  { name: 'Product', href: '#how-it-works' },
-  { name: 'Pricing', href: '#' },
-  { name: 'Contact', href: '/contact' },
+  { name: 'Product', to: '#how-it-works' },
+  { name: 'Pricing', to: '#' },
+  { name: 'Contact', to: '/contact' },
 ]
 
 export default function Hero() {
@@ -41,13 +41,13 @@ export default function Hero() {
           </div>
           <div className="hidden lg:flex lg:gap-x-12">
             {navigation.map((item) => (
-              <a
+              <Link
                 key={item.name}
-                href={item.href}
+                to={item.to}
                 className="text-sm font-semibold text-gray-900 hover:text-gray-700"
               >
                 {item.name}
-              </a>
+              </Link>
             ))}
           </div>
           <div className="hidden lg:flex lg:flex-1 lg:justify-end">
@@ -89,13 +89,13 @@ export default function Hero() {
               <div className="-my-6 divide-y divide-gray-500/10">
                 <div className="space-y-2 py-6">
                   {navigation.map((item) => (
-                    <a
+                    <Link
                       key={item.name}
-                      href={item.href}
+                      to={item.to}
                       className="-mx-3 block rounded-lg px-3 py-2 text-base font-semibold text-gray-900 hover:bg-gray-50"
                     >
                       {item.name}
-                    </a>
+                    </Link>
                   ))}
                 </div>
                 <div className="py-6">


### PR DESCRIPTION
## Summary
- replace anchor tags in HeroSection navigation with React Router `Link`
- switch navigation items to use a `to` field for internal routing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689bff91743c832eb7324d0b1de620a9