### PR TITLE
Select Clerk key based on origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,19 +70,14 @@ boardbid-ui/
 
 ## 🔐 Authentication
 
-This project uses [Clerk](https://clerk.com/docs/quickstarts/react) for user management. Create a `.env` file at the project root with your **development** key:
+This project uses [Clerk](https://clerk.com/docs/quickstarts/react) for user management. Provide both development and production publishable keys in your `.env`:
 
 ```
 VITE_CLERK_PUBLISHABLE_KEY=pk_test_aW50ZW5zZS1zY29ycGlvbi00Ny5jbGVyay5hY2NvdW50cy5kZXYk
+VITE_CLERK_PUBLISHABLE_KEY_PROD=pk_live_Y2xlcmsuYm9hcmRiaWQuYWkk
 ```
 
-For production builds, supply your live publishable key. You can do this by creating a `.env.production` file:
-
-```
-VITE_CLERK_PUBLISHABLE_KEY=pk_live_Y2xlcmsuYm9hcmRiaWQuYWkk
-```
-
-The application expects this key at runtime.
+At runtime the app selects the development key when served from `localhost` or `https://saivaraprasad-avula.github.io/boardbid-ui/` and falls back to the production key for all other origins.
 
 Authenticated users can access dashboards, campaign tools, and manage their profile on `/account`.
 

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -6,7 +6,14 @@ import { withBase } from './utils/basePath.js';
 import './index.css';
 import App from './App.jsx';
 
-const PUBLISHABLE_KEY = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY;
+const hostname = window.location.hostname;
+const isLocal = hostname === 'localhost';
+const isGhPages = hostname === 'saivaraprasad-avula.github.io';
+const PUBLISHABLE_KEY =
+  isLocal || isGhPages
+    ? import.meta.env.VITE_CLERK_PUBLISHABLE_KEY
+    : import.meta.env.VITE_CLERK_PUBLISHABLE_KEY_PROD;
+
 if (!PUBLISHABLE_KEY) {
   throw new Error('Missing Clerk Publishable Key');
 }


### PR DESCRIPTION
## Summary
- Choose Clerk publishable key based on hostname so localhost and GitHub Pages use the dev key
- Document both development and production Clerk keys in README

## Testing
- `npm test` *(fails: Missing script)*
- `VITE_CLERK_PUBLISHABLE_KEY=pk_test_dummy VITE_CLERK_PUBLISHABLE_KEY_PROD=pk_live_dummy npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c8c1ed7b0832e9a7bc4e4e7ab54c6