### PR TITLE
Use dev Clerk key for non-boardbid domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ VITE_CLERK_PUBLISHABLE_KEY=pk_test_aW50ZW5zZS1zY29ycGlvbi00Ny5jbGVyay5hY2NvdW50c
 VITE_CLERK_PUBLISHABLE_KEY_PROD=pk_live_Y2xlcmsuYm9hcmRiaWQuYWkk
 ```
 
-At runtime the app selects the development key when served from `localhost` or `https://saivaraprasad-avula.github.io/boardbid-ui/` and falls back to the production key for all other origins.
+At runtime the app loads the production key only when served from `boardbid.ai` or its subdomains. All other origins, including `localhost` and the GitHub Pages demo, use the development key.
 
 Authenticated users can access dashboards, campaign tools, and manage their profile on `/account`.
 

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -7,12 +7,11 @@ import './index.css';
 import App from './App.jsx';
 
 const hostname = window.location.hostname;
-const isLocal = hostname === 'localhost';
-const isGhPages = hostname === 'saivaraprasad-avula.github.io';
-const PUBLISHABLE_KEY =
-  isLocal || isGhPages
-    ? import.meta.env.VITE_CLERK_PUBLISHABLE_KEY
-    : import.meta.env.VITE_CLERK_PUBLISHABLE_KEY_PROD;
+const isBoardBidDomain =
+  hostname === 'boardbid.ai' || hostname.endsWith('.boardbid.ai');
+const PUBLISHABLE_KEY = isBoardBidDomain
+  ? import.meta.env.VITE_CLERK_PUBLISHABLE_KEY_PROD
+  : import.meta.env.VITE_CLERK_PUBLISHABLE_KEY;
 
 if (!PUBLISHABLE_KEY) {
   throw new Error('Missing Clerk Publishable Key');


### PR DESCRIPTION
## Summary
- Only load production Clerk publishable key on `boardbid.ai` or its subdomains
- Clarify authentication environment selection in README

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c93033178832ebdb18139447f6d0a