### PR TITLE
Fix dashboard navigation links and ensure pages load from top

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,5 @@
 import { Routes, Route } from 'react-router-dom';
+import ScrollToTop from './components/ScrollToTop.jsx';
 import Home from './pages/Home';
 import SignInPage from './pages/SignIn';
 import SignUpPage from './pages/SignUp';
@@ -20,7 +21,9 @@ import ProtectedRoute from './components/ProtectedRoute';
 
 function App() {
   return (
-    <Routes>
+    <>
+      <ScrollToTop />
+      <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/login" element={<SignInPage />} />
         <Route path="/sign-up" element={<SignUpPage />} />
@@ -38,7 +41,8 @@ function App() {
         <Route path="/contact" element={<Contact />} />
         <Route path="/terms" element={<TermsOfService />} />
         <Route path="/privacy" element={<PrivacyPolicy />} />
-    </Routes>
+      </Routes>
+    </>
   );
 }
 

--- a/src/components/HeroSection.jsx
+++ b/src/components/HeroSection.jsx
@@ -41,15 +41,25 @@ export default function Hero() {
             </button>
           </div>
           <div className="hidden lg:flex lg:gap-x-12">
-            {navigation.map((item) => (
-              <Link
-                key={item.name}
-                to={item.to}
-                className="text-sm font-semibold text-gray-900 hover:text-gray-700"
-              >
-                {item.name}
-              </Link>
-            ))}
+            {navigation.map((item) =>
+              item.to.startsWith('#') ? (
+                <a
+                  key={item.name}
+                  href={item.to}
+                  className="text-sm font-semibold text-gray-900 hover:text-gray-700"
+                >
+                  {item.name}
+                </a>
+              ) : (
+                <Link
+                  key={item.name}
+                  to={item.to}
+                  className="text-sm font-semibold text-gray-900 hover:text-gray-700"
+                >
+                  {item.name}
+                </Link>
+              )
+            )}
           </div>
           <div className="hidden lg:flex lg:flex-1 lg:justify-end">
             <SignedOut>
@@ -89,15 +99,25 @@ export default function Hero() {
             <div className="mt-6 flow-root">
               <div className="-my-6 divide-y divide-gray-500/10">
                 <div className="space-y-2 py-6">
-                  {navigation.map((item) => (
-                    <Link
-                      key={item.name}
-                      to={item.to}
-                      className="-mx-3 block rounded-lg px-3 py-2 text-base font-semibold text-gray-900 hover:bg-gray-50"
-                    >
-                      {item.name}
-                    </Link>
-                  ))}
+                  {navigation.map((item) =>
+                    item.to.startsWith('#') ? (
+                      <a
+                        key={item.name}
+                        href={item.to}
+                        className="-mx-3 block rounded-lg px-3 py-2 text-base font-semibold text-gray-900 hover:bg-gray-50"
+                      >
+                        {item.name}
+                      </a>
+                    ) : (
+                      <Link
+                        key={item.name}
+                        to={item.to}
+                        className="-mx-3 block rounded-lg px-3 py-2 text-base font-semibold text-gray-900 hover:bg-gray-50"
+                      >
+                        {item.name}
+                      </Link>
+                    )
+                  )}
                 </div>
                 <div className="py-6">
                   <SignedOut>

--- a/src/components/ScrollToTop.jsx
+++ b/src/components/ScrollToTop.jsx
@@ -1,0 +1,12 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+export default function ScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+}

--- a/src/layout/InternalLayout.jsx
+++ b/src/layout/InternalLayout.jsx
@@ -30,7 +30,7 @@ const navigation = [
 
 const teams = [
   { id: 1, name: 'Packages', href: '#', initial: 'P', current: false },
-  { id: 2, name: 'Blogs', href: '#', initial: 'B', current: false },
+  { id: 2, name: 'Blogs', href: '/blogs', initial: 'B', current: false },
   { id: 3, name: 'Support', href: '/contact', initial: 'S', current: false },
 ];
 
@@ -60,11 +60,13 @@ export default function InternalLayout({ children }) {
 
               <div className="flex grow flex-col gap-y-8 overflow-y-auto bg-white px-6 pb-4">
                 <div className="flex h-16 shrink-0 items-center">
-                  <img
-                    alt="Boardbid Logo"
-                    src="https://ik.imagekit.io/boardbid/logo-optimized.avif?updatedAt=1748049683476"
-                    className="h-8 w-auto"
-                  />
+                  <Link to="/">
+                    <img
+                      alt="Boardbid Logo"
+                      src="https://ik.imagekit.io/boardbid/logo-optimized.avif?updatedAt=1748049683476"
+                      className="h-8 w-auto"
+                    />
+                  </Link>
                 </div>
                 <nav className="flex flex-1 flex-col">
                   <ul role="list" className="flex flex-1 flex-col gap-y-7">
@@ -100,8 +102,8 @@ export default function InternalLayout({ children }) {
                       <ul role="list" className="-mx-2 mt-2 space-y-1">
                         {teams.map((team) => (
                           <li key={team.name}>
-                            <a
-                              href={team.href}
+                            <Link
+                              to={team.href}
                               className={classNames(
                                 team.current
                                   ? 'bg-gray-50 text-[#288dcf]'
@@ -120,7 +122,7 @@ export default function InternalLayout({ children }) {
                                 {team.initial}
                               </span>
                               <span className="truncate">{team.name}</span>
-                            </a>
+                            </Link>
                           </li>
                         ))}
                       </ul>
@@ -135,11 +137,13 @@ export default function InternalLayout({ children }) {
         <div className="hidden lg:fixed lg:inset-y-0 lg:z-50 lg:flex lg:w-72 lg:flex-col">
           <div className="flex grow flex-col gap-y-8 overflow-y-auto bg-white px-6 pb-4 border-r border-gray-200">
             <div className="flex h-16 shrink-0 items-center">
-              <img
-                alt="Boardbid Logo"
-                src="https://ik.imagekit.io/boardbid/BoardBid%20logo.svg"
-                className="h-8 w-auto"
-              />
+              <Link to="/">
+                <img
+                  alt="Boardbid Logo"
+                  src="https://ik.imagekit.io/boardbid/BoardBid%20logo.svg"
+                  className="h-8 w-auto"
+                />
+              </Link>
             </div>
             <nav className="flex flex-1 flex-col">
               <ul role="list" className="flex flex-1 flex-col gap-y-7">
@@ -175,8 +179,8 @@ export default function InternalLayout({ children }) {
                   <ul role="list" className="-mx-2 mt-2 space-y-1">
                     {teams.map((team) => (
                       <li key={team.name}>
-                        <a
-                          href={team.href}
+                        <Link
+                          to={team.href}
                           className={classNames(
                             team.current
                               ? 'bg-gray-50 text-[#288dcf]'
@@ -195,7 +199,7 @@ export default function InternalLayout({ children }) {
                             {team.initial}
                           </span>
                           <span className="truncate">{team.name}</span>
-                        </a>
+                        </Link>
                       </li>
                     ))}
                   </ul>


### PR DESCRIPTION
## Summary
- Make Product navigation use anchor link to reach How It Works
- Link dashboard logos to landing page and point Blogs item to /blogs
- Add ScrollToTop to reset scroll position on route changes

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d8ae26eb0832eb9968678579be5fd