### PR TITLE
Refine footer and dashboard navigation

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,5 +1,5 @@
 // src/components/Footer.jsx
-import { SignUpButton } from '@clerk/clerk-react';
+import { SignUpButton, SignedIn, SignedOut } from '@clerk/clerk-react';
 import { Link } from 'react-router-dom';
 import { withBase } from '../utils/basePath.js';
 
@@ -57,13 +57,24 @@ export default function Footer() {
             We plan and manage your billboard campaigns end-to-end from strategy to booking, built around your goals.
           </p>
           <div className="mt-8 flex justify-center">
-            <SignUpButton mode="modal" afterSignUpUrl={withBase('/dashboard')}>
-              <button
-                className="rounded-md bg-indigo-500 px-3.5 py-2.5 text-sm font-semibold text-white shadow-xs hover:bg-indigo-400 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500"
-              >
-                Get started
-              </button>
-            </SignUpButton>
+            <SignedOut>
+              <SignUpButton mode="modal" afterSignUpUrl={withBase('/dashboard')}>
+                <button
+                  className="rounded-md bg-indigo-500 px-3.5 py-2.5 text-sm font-semibold text-white shadow-xs hover:bg-indigo-400 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500"
+                >
+                  Get started
+                </button>
+              </SignUpButton>
+            </SignedOut>
+            <SignedIn>
+              <Link to="/dashboard">
+                <button
+                  className="rounded-md bg-indigo-500 px-3.5 py-2.5 text-sm font-semibold text-white shadow-xs hover:bg-indigo-400 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500"
+                >
+                  Dashboard
+                </button>
+              </Link>
+            </SignedIn>
           </div>
         </div>
         <div className="mt-24 border-t border-white/10 pt-12 xl:grid xl:grid-cols-3 xl:gap-8">

--- a/src/layout/InternalLayout.jsx
+++ b/src/layout/InternalLayout.jsx
@@ -10,7 +10,7 @@ import {
 } from '@headlessui/react';
 import {
   Bars3Icon,
-  BellIcon,
+  /* BellIcon, */
   DocumentDuplicateIcon,
   FolderIcon,
   HomeIcon,
@@ -29,7 +29,6 @@ const navigation = [
 ];
 
 const teams = [
-  { id: 1, name: 'Packages', href: '#', initial: 'P', current: false },
   { id: 2, name: 'Blogs', href: '/blogs', initial: 'B', current: false },
   { id: 3, name: 'Support', href: '/contact', initial: 'S', current: false },
 ];
@@ -218,10 +217,12 @@ export default function InternalLayout({ children }) {
             <div aria-hidden="true" className="h-6 w-px bg-gray-200 lg:hidden" />
             <div className="flex flex-1 justify-end gap-x-4 self-stretch lg:gap-x-6">
               <div className="flex items-center gap-x-4 lg:gap-x-6">
+                {/*
                 <button type="button" className="-m-2.5 p-2.5 text-gray-400 hover:text-gray-500">
                   <span className="sr-only">View notifications</span>
                   <BellIcon className="size-6" />
                 </button>
+                */}
                 <div aria-hidden="true" className="hidden lg:block lg:h-6 lg:w-px lg:bg-gray-200" />
                 <UserButton
                   afterSignOutUrl={withBase('/')}


### PR DESCRIPTION
## Summary
- Use Clerk's SignedIn/SignedOut in footer so logged-in users go to dashboard
- Remove Packages entry from dashboard sidebar and hide notifications button

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d922c1d10832e89022718418bfa22