### PR TITLE
refactor hero and footer sections

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,7 +1,6 @@
 // src/components/Footer.jsx
-import { SignUpButton, SignedIn, SignedOut } from '@clerk/clerk-react';
 import { Link } from 'react-router-dom';
-import { withBase } from '../utils/basePath.js';
+import FooterCTA from './FooterCTA.jsx';
 
 const navigation = {
   support: [
@@ -46,37 +45,7 @@ export default function Footer() {
   return (
     <footer className="bg-gray-900">
       <div className="mx-auto max-w-7xl px-6 py-16 sm:py-24 lg:px-8 lg:py-32">
-        <div className="mx-auto max-w-2xl text-center">
-          <hgroup>
-          <h2 className="text-base/6 font-semibold font-sans text-indigo-400">Out-of-home, without the overwhelm</h2>
-            <p className="mt-2 text-4xl font-semibold font-sans tracking-tight text-white sm:text-5xl">
-              Turn Heads. Drive Growth.
-            </p>
-          </hgroup>
-          <p className="mx-auto mt-6 max-w-xl text-lg text-gray-400">
-            We plan and manage your billboard campaigns end-to-end from strategy to booking, built around your goals.
-          </p>
-          <div className="mt-8 flex justify-center">
-            <SignedOut>
-              <SignUpButton mode="modal" afterSignUpUrl={withBase('/dashboard')}>
-                <button
-                  className="rounded-md bg-indigo-500 px-3.5 py-2.5 text-sm font-semibold text-white shadow-xs hover:bg-indigo-400 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500"
-                >
-                  Get started
-                </button>
-              </SignUpButton>
-            </SignedOut>
-            <SignedIn>
-              <Link to="/dashboard">
-                <button
-                  className="rounded-md bg-indigo-500 px-3.5 py-2.5 text-sm font-semibold text-white shadow-xs hover:bg-indigo-400 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500"
-                >
-                  Dashboard
-                </button>
-              </Link>
-            </SignedIn>
-          </div>
-        </div>
+        <FooterCTA />
         <div className="mt-24 border-t border-white/10 pt-12 xl:grid xl:grid-cols-3 xl:gap-8">
           <img
             alt="Boardbid.ai Logo"

--- a/src/components/FooterCTA.jsx
+++ b/src/components/FooterCTA.jsx
@@ -1,0 +1,39 @@
+import { SignUpButton, SignedIn, SignedOut } from '@clerk/clerk-react'
+import { Link } from 'react-router-dom'
+import { withBase } from '../utils/basePath.js'
+
+export default function FooterCTA() {
+  return (
+    <div className="mx-auto max-w-2xl text-center">
+      <hgroup>
+        <h2 className="text-base/6 font-semibold font-sans text-indigo-400">Out-of-home, without the overwhelm</h2>
+        <p className="mt-2 text-4xl font-semibold font-sans tracking-tight text-white sm:text-5xl">
+          Turn Heads. Drive Growth.
+        </p>
+      </hgroup>
+      <p className="mx-auto mt-6 max-w-xl text-lg text-gray-400">
+        We plan and manage your billboard campaigns end-to-end from strategy to booking, built around your goals.
+      </p>
+      <div className="mt-8 flex justify-center">
+        <SignedOut>
+          <SignUpButton mode="modal" afterSignUpUrl={withBase('/dashboard')}>
+            <button
+              className="rounded-md bg-indigo-500 px-3.5 py-2.5 text-sm font-semibold text-white shadow-xs hover:bg-indigo-400 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500"
+            >
+              Get started
+            </button>
+          </SignUpButton>
+        </SignedOut>
+        <SignedIn>
+          <Link to="/dashboard">
+            <button
+              className="rounded-md bg-indigo-500 px-3.5 py-2.5 text-sm font-semibold text-white shadow-xs hover:bg-indigo-400 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500"
+            >
+              Dashboard
+            </button>
+          </Link>
+        </SignedIn>
+      </div>
+    </div>
+  )
+}

--- a/src/components/HeroHeader.jsx
+++ b/src/components/HeroHeader.jsx
@@ -1,0 +1,144 @@
+'use client'
+
+import { useState } from 'react'
+import { Link } from 'react-router-dom'
+import { Dialog, DialogPanel } from '@headlessui/react'
+import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/outline'
+import { SignedIn, SignedOut, SignInButton } from '@clerk/clerk-react'
+import { withBase } from '../utils/basePath.js'
+
+const navigation = [
+  { name: 'Product', to: '#how-it-works' },
+  { name: 'Pricing', to: '#' },
+  { name: 'Contact', to: '/contact' },
+]
+
+export default function HeroHeader() {
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
+
+  return (
+    <header className="absolute inset-x-0 top-0 z-50">
+      <nav aria-label="Global" className="flex items-center justify-between p-6 lg:px-8">
+        <div className="flex lg:flex-1">
+          <Link to="/" className="-m-1.5 p-1.5">
+            <span className="sr-only">BoardBid.ai</span>
+            <img
+              alt="BoardBid logo"
+              src="https://ik.imagekit.io/boardbid/BoardBid%20final.avif?updatedAt=1755054268128"
+              className="h-8 w-auto"
+            />
+          </Link>
+        </div>
+        <div className="flex lg:hidden">
+          <button
+            type="button"
+            onClick={() => setMobileMenuOpen(true)}
+            className="-m-2.5 inline-flex items-center justify-center rounded-md p-2.5 text-gray-700"
+          >
+            <Bars3Icon aria-hidden="true" className="size-6" />
+          </button>
+        </div>
+        <div className="hidden lg:flex lg:gap-x-12">
+          {navigation.map((item) =>
+            item.to.startsWith('#') ? (
+              <a
+                key={item.name}
+                href={item.to}
+                className="text-sm font-semibold text-gray-900 hover:text-gray-700"
+              >
+                {item.name}
+              </a>
+            ) : (
+              <Link
+                key={item.name}
+                to={item.to}
+                className="text-sm font-semibold text-gray-900 hover:text-gray-700"
+              >
+                {item.name}
+              </Link>
+            )
+          )}
+        </div>
+        <div className="hidden lg:flex lg:flex-1 lg:justify-end">
+          <SignedOut>
+            <SignInButton mode="modal" afterSignInUrl={withBase('/dashboard')}>
+              <button className="text-sm font-semibold text-gray-900 hover:text-indigo-600">
+                Log in <span aria-hidden="true">&rarr;</span>
+              </button>
+            </SignInButton>
+          </SignedOut>
+          <SignedIn>
+            <Link to="/dashboard" className="text-sm font-semibold text-gray-900 hover:text-indigo-600">
+              Dashboard <span aria-hidden="true">&rarr;</span>
+            </Link>
+          </SignedIn>
+        </div>
+      </nav>
+
+      <Dialog open={mobileMenuOpen} onClose={setMobileMenuOpen} className="lg:hidden">
+        <div className="fixed inset-0 z-50" />
+        <DialogPanel className="fixed inset-y-0 right-0 z-50 w-full overflow-y-auto bg-white p-6 sm:max-w-sm sm:ring-1 sm:ring-gray-900/10">
+          <div className="flex items-center justify-between">
+            <Link to="/" className="-m-1.5 p-1.5">
+              <img
+                alt="BoardBid logo Mobile"
+                src="https://ik.imagekit.io/boardbid/BoardBid%20final.avif?updatedAt=1755054268128"
+                className="h-16 w-auto"
+              />
+            </Link>
+            <button
+              type="button"
+              onClick={() => setMobileMenuOpen(false)}
+              className="-m-2.5 rounded-md p-2.5 text-gray-700"
+            >
+              <XMarkIcon aria-hidden="true" className="size-6" />
+            </button>
+          </div>
+          <div className="mt-6 flow-root">
+            <div className="-my-6 divide-y divide-gray-500/10">
+              <div className="space-y-2 py-6">
+                {navigation.map((item) =>
+                  item.to.startsWith('#') ? (
+                    <a
+                      key={item.name}
+                      href={item.to}
+                      className="-mx-3 block rounded-lg px-3 py-2 text-base font-semibold text-gray-900 hover:bg-gray-50"
+                    >
+                      {item.name}
+                    </a>
+                  ) : (
+                    <Link
+                      key={item.name}
+                      to={item.to}
+                      className="-mx-3 block rounded-lg px-3 py-2 text-base font-semibold text-gray-900 hover:bg-gray-50"
+                    >
+                      {item.name}
+                    </Link>
+                  )
+                )}
+              </div>
+              <div className="py-6">
+                <SignedOut>
+                  <SignInButton mode="modal" afterSignInUrl={withBase('/dashboard')}>
+                    <button className="-mx-3 block rounded-lg px-3 py-2.5 text-base font-semibold text-gray-900 hover:bg-gray-50">
+                      Log in
+                    </button>
+                  </SignInButton>
+                </SignedOut>
+                <SignedIn>
+                  <Link
+                    to="/dashboard"
+                    className="-mx-3 block rounded-lg px-3 py-2.5 text-base font-semibold text-gray-900 hover:bg-gray-50"
+                  >
+                    Dashboard
+                  </Link>
+                </SignedIn>
+              </div>
+            </div>
+          </div>
+        </DialogPanel>
+      </Dialog>
+    </header>
+  )
+}
+

--- a/src/components/HeroSection.jsx
+++ b/src/components/HeroSection.jsx
@@ -1,146 +1,15 @@
 'use client'
 
-import { useState } from 'react'
 import { Link } from 'react-router-dom'
-import { Dialog, DialogPanel } from '@headlessui/react'
-import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/outline'
-import { SignedIn, SignedOut, SignInButton, SignUpButton } from '@clerk/clerk-react'
+import { SignedIn, SignedOut, SignUpButton } from '@clerk/clerk-react'
 import { withBase } from '../utils/basePath.js'
-
-const navigation = [
-  { name: 'Product', to: '#how-it-works' },
-  { name: 'Pricing', to: '#' },
-  { name: 'Contact', to: '/contact' },
-]
+import HeroHeader from './HeroHeader.jsx'
 
 export default function Hero() {
-  const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
-
+  
   return (
     <div className="bg-white">
-      {/* Header (unchanged for desktop) */}
-      <header className="absolute inset-x-0 top-0 z-50">
-        <nav aria-label="Global" className="flex items-center justify-between p-6 lg:px-8">
-          <div className="flex lg:flex-1">
-            <Link to="/" className="-m-1.5 p-1.5">
-              <span className="sr-only">BoardBid.ai</span>
-              <img
-                alt="BoardBid logo"
-                src="https://ik.imagekit.io/boardbid/BoardBid%20final.avif?updatedAt=1755054268128"
-                className="h-8 w-auto"
-              />
-            </Link>
-          </div>
-          <div className="flex lg:hidden">
-            <button
-              type="button"
-              onClick={() => setMobileMenuOpen(true)}
-              className="-m-2.5 inline-flex items-center justify-center rounded-md p-2.5 text-gray-700"
-            >
-              <Bars3Icon aria-hidden="true" className="size-6" />
-            </button>
-          </div>
-          <div className="hidden lg:flex lg:gap-x-12">
-            {navigation.map((item) =>
-              item.to.startsWith('#') ? (
-                <a
-                  key={item.name}
-                  href={item.to}
-                  className="text-sm font-semibold text-gray-900 hover:text-gray-700"
-                >
-                  {item.name}
-                </a>
-              ) : (
-                <Link
-                  key={item.name}
-                  to={item.to}
-                  className="text-sm font-semibold text-gray-900 hover:text-gray-700"
-                >
-                  {item.name}
-                </Link>
-              )
-            )}
-          </div>
-          <div className="hidden lg:flex lg:flex-1 lg:justify-end">
-            <SignedOut>
-              <SignInButton mode="modal" afterSignInUrl={withBase('/dashboard')}>
-                <button className="text-sm font-semibold text-gray-900 hover:text-indigo-600">
-                  Log in <span aria-hidden="true">&rarr;</span>
-                </button>
-              </SignInButton>
-            </SignedOut>
-            <SignedIn>
-              <Link to="/dashboard" className="text-sm font-semibold text-gray-900 hover:text-indigo-600">
-                Dashboard <span aria-hidden="true">&rarr;</span>
-              </Link>
-            </SignedIn>
-          </div>
-        </nav>
-
-        <Dialog open={mobileMenuOpen} onClose={setMobileMenuOpen} className="lg:hidden">
-          <div className="fixed inset-0 z-50" />
-          <DialogPanel className="fixed inset-y-0 right-0 z-50 w-full overflow-y-auto bg-white p-6 sm:max-w-sm sm:ring-1 sm:ring-gray-900/10">
-            <div className="flex items-center justify-between">
-              <Link to="/" className="-m-1.5 p-1.5">
-                <img
-                  alt="BoardBid logo Mobile"
-                  src="https://ik.imagekit.io/boardbid/BoardBid%20final.avif?updatedAt=1755054268128"
-                  className="h-16 w-auto"
-                />
-              </Link>
-              <button
-                type="button"
-                onClick={() => setMobileMenuOpen(false)}
-                className="-m-2.5 rounded-md p-2.5 text-gray-700"
-              >
-                <XMarkIcon aria-hidden="true" className="size-6" />
-              </button>
-            </div>
-            <div className="mt-6 flow-root">
-              <div className="-my-6 divide-y divide-gray-500/10">
-                <div className="space-y-2 py-6">
-                  {navigation.map((item) =>
-                    item.to.startsWith('#') ? (
-                      <a
-                        key={item.name}
-                        href={item.to}
-                        className="-mx-3 block rounded-lg px-3 py-2 text-base font-semibold text-gray-900 hover:bg-gray-50"
-                      >
-                        {item.name}
-                      </a>
-                    ) : (
-                      <Link
-                        key={item.name}
-                        to={item.to}
-                        className="-mx-3 block rounded-lg px-3 py-2 text-base font-semibold text-gray-900 hover:bg-gray-50"
-                      >
-                        {item.name}
-                      </Link>
-                    )
-                  )}
-                </div>
-                <div className="py-6">
-                  <SignedOut>
-                    <SignInButton mode="modal" afterSignInUrl={withBase('/dashboard')}>
-                      <button className="-mx-3 block rounded-lg px-3 py-2.5 text-base font-semibold text-gray-900 hover:bg-gray-50">
-                        Log in
-                      </button>
-                    </SignInButton>
-                  </SignedOut>
-                  <SignedIn>
-                    <Link
-                      to="/dashboard"
-                      className="-mx-3 block rounded-lg px-3 py-2.5 text-base font-semibold text-gray-900 hover:bg-gray-50"
-                    >
-                      Dashboard
-                    </Link>
-                  </SignedIn>
-                </div>
-              </div>
-            </div>
-          </DialogPanel>
-        </Dialog>
-      </header>
+      <HeroHeader />
 
       {/* Hero Section */}
       {/* MOBILE-ONLY TWEAKS: smaller paddings & card width; DESKTOP remains as you had it */}

--- a/src/components/WelcomeBack.jsx
+++ b/src/components/WelcomeBack.jsx
@@ -19,7 +19,7 @@ export default function WelcomeBack() {
               <img
                 alt=""
                 src={user?.imageUrl}
-                className="mx-auto size-20 rounded-full dark:outline dark:-outline-offset-1 dark:outline-white/10"
+                className="mx-auto h-20 w-20 rounded-full object-cover aspect-square dark:outline dark:-outline-offset-1 dark:outline-white/10"
               />
             </div>
             <div className="mt-4 text-center sm:mt-0 sm:pt-1 sm:text-left">


### PR DESCRIPTION
## Summary
- extract landing page header into new `HeroHeader` component used by HeroSection
- move footer call-to-action into new `FooterCTA` component
- avoid distorted user avatar in dashboard by using object-fit styling

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ef4e3e550832eae6b46cf892dcf97