### PR TITLE
Separate FooterCTA from Footer component

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,6 +1,5 @@
 // src/components/Footer.jsx
 import { Link } from 'react-router-dom';
-import FooterCTA from './FooterCTA.jsx';
 
 const navigation = {
   support: [
@@ -44,8 +43,7 @@ const navigation = {
 export default function Footer() {
   return (
     <footer className="bg-gray-900">
-      <div className="mx-auto max-w-7xl px-6 py-16 sm:py-24 lg:px-8 lg:py-32">
-        <FooterCTA />
+      <div className="mx-auto max-w-7xl px-6 pb-16 sm:pb-24 lg:px-8 lg:pb-32">
         <div className="mt-24 border-t border-white/10 pt-12 xl:grid xl:grid-cols-3 xl:gap-8">
           <img
             alt="Boardbid.ai Logo"

--- a/src/components/FooterCTA.jsx
+++ b/src/components/FooterCTA.jsx
@@ -4,35 +4,39 @@ import { withBase } from '../utils/basePath.js'
 
 export default function FooterCTA() {
   return (
-    <div className="mx-auto max-w-2xl text-center">
-      <hgroup>
-        <h2 className="text-base/6 font-semibold font-sans text-indigo-400">Out-of-home, without the overwhelm</h2>
-        <p className="mt-2 text-4xl font-semibold font-sans tracking-tight text-white sm:text-5xl">
-          Turn Heads. Drive Growth.
-        </p>
-      </hgroup>
-      <p className="mx-auto mt-6 max-w-xl text-lg text-gray-400">
-        We plan and manage your billboard campaigns end-to-end from strategy to booking, built around your goals.
-      </p>
-      <div className="mt-8 flex justify-center">
-        <SignedOut>
-          <SignUpButton mode="modal" afterSignUpUrl={withBase('/dashboard')}>
-            <button
-              className="rounded-md bg-indigo-500 px-3.5 py-2.5 text-sm font-semibold text-white shadow-xs hover:bg-indigo-400 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500"
-            >
-              Get started
-            </button>
-          </SignUpButton>
-        </SignedOut>
-        <SignedIn>
-          <Link to="/dashboard">
-            <button
-              className="rounded-md bg-indigo-500 px-3.5 py-2.5 text-sm font-semibold text-white shadow-xs hover:bg-indigo-400 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500"
-            >
-              Dashboard
-            </button>
-          </Link>
-        </SignedIn>
+    <div className="bg-gray-900">
+      <div className="mx-auto max-w-7xl px-6 pt-16 sm:pt-24 lg:px-8 lg:pt-32">
+        <div className="mx-auto max-w-2xl text-center">
+          <hgroup>
+            <h2 className="text-base/6 font-semibold font-sans text-indigo-400">Out-of-home, without the overwhelm</h2>
+            <p className="mt-2 text-4xl font-semibold font-sans tracking-tight text-white sm:text-5xl">
+              Turn Heads. Drive Growth.
+            </p>
+          </hgroup>
+          <p className="mx-auto mt-6 max-w-xl text-lg text-gray-400">
+            We plan and manage your billboard campaigns end-to-end from strategy to booking, built around your goals.
+          </p>
+          <div className="mt-8 flex justify-center">
+            <SignedOut>
+              <SignUpButton mode="modal" afterSignUpUrl={withBase('/dashboard')}>
+                <button
+                  className="rounded-md bg-indigo-500 px-3.5 py-2.5 text-sm font-semibold text-white shadow-xs hover:bg-indigo-400 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500"
+                >
+                  Get started
+                </button>
+              </SignUpButton>
+            </SignedOut>
+            <SignedIn>
+              <Link to="/dashboard">
+                <button
+                  className="rounded-md bg-indigo-500 px-3.5 py-2.5 text-sm font-semibold text-white shadow-xs hover:bg-indigo-400 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500"
+                >
+                  Dashboard
+                </button>
+              </Link>
+            </SignedIn>
+          </div>
+        </div>
       </div>
     </div>
   )

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -7,6 +7,7 @@ import TargetLocations from '../components/TargetLocations';
 import WhyChoose from '../components/WhyChoose';
 import BlogFlyer from '../components/BlogFlyer';
 import Footer from '../components/Footer';
+import FooterCTA from '../components/FooterCTA';
 import MediaFormatsBento from "../components/VenuesSection";
 import { posts } from '../data/blogs';
 import Intercom from '../components/intercom-landing';
@@ -22,6 +23,7 @@ export default function Home() {
       <TargetLocations />
       <WhyChoose />
       <BlogFlyer posts={posts} />
+      <FooterCTA />
       <Footer />
       <Intercom />
     </>


### PR DESCRIPTION
## Summary
- render `FooterCTA` separately on the Home page
- strip `FooterCTA` import and call from `Footer` and adjust layout padding
- move layout wrappers into `FooterCTA` so Home renders components directly

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a2b1ea9494832ebb5b3821c64a6047