### PR TITLE
Remove extra spacing before footer

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -44,7 +44,7 @@ export default function Footer() {
   return (
     <footer className="bg-gray-900">
       <div className="mx-auto max-w-7xl px-6 pb-16 sm:pb-24 lg:px-8 lg:pb-32">
-        <div className="mt-24 border-t border-white/10 pt-12 xl:grid xl:grid-cols-3 xl:gap-8">
+        <div className="border-t border-white/10 pt-12 xl:grid xl:grid-cols-3 xl:gap-8">
           <img
             alt="Boardbid.ai Logo"
             src="https://ik.imagekit.io/boardbid/BoardBid%20logo-White.avif"


### PR DESCRIPTION
## Summary
- remove top margin from footer navigation section to eliminate gap under call-to-action

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a2b8d7509c832e881a43f317db11a7