### PR TITLE
Add pricing CTA component and route

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,6 +17,7 @@ import About from './pages/About';
 import Press from './pages/Press';
 import Support from './pages/Support';
 import Contact from './pages/Contact';
+import Pricing from './pages/Pricing';
 import ProtectedRoute from './components/ProtectedRoute';
 
 function App() {
@@ -39,6 +40,7 @@ function App() {
         <Route path="/press" element={<Press />} />
         <Route path="/support" element={<Support />} />
         <Route path="/contact" element={<Contact />} />
+        <Route path="/pricing" element={<Pricing />} />
         <Route path="/terms" element={<TermsOfService />} />
         <Route path="/privacy" element={<PrivacyPolicy />} />
       </Routes>

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -45,7 +45,7 @@ const navigation = {
 export default function Footer() {
   return (
     <footer className="bg-gray-900">
-      <div className="mx-auto max-w-7xl px-6 py-16 sm:py-24 lg:px-8 lg:py-32">
+      <div className="mx-auto max-w-7xl px-6 pt-16 pb-8 sm:pt-24 sm:pb-8 lg:px-8 lg:pt-32 lg:pb-8">
         <div className="mx-auto max-w-2xl text-center">
           <hgroup>
           <h2 className="text-base/6 font-semibold font-sans text-indigo-400">Out-of-home, without the overwhelm</h2>

--- a/src/components/PricingCTA.jsx
+++ b/src/components/PricingCTA.jsx
@@ -1,0 +1,28 @@
+import { Link } from 'react-router-dom'
+
+export default function PricingCTA() {
+  return (
+    <div className="bg-indigo-100">
+      <div className="mx-auto max-w-7xl px-6 py-24 sm:py-32 lg:flex lg:items-center lg:justify-between lg:px-8">
+        <h2 className="max-w-2xl text-4xl font-semibold tracking-tight text-gray-900 sm:text-5xl">
+          Ready to simplify out-of-home?
+          <br />
+          Launch your campaign for free.
+        </h2>
+        <div className="mt-10 flex items-center gap-x-6 lg:mt-0 lg:shrink-0">
+          <Link
+            to="#"
+            className="rounded-md bg-indigo-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-xs hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+          >
+            Get started
+          </Link>
+          <Link to="#" className="text-sm/6 font-semibold text-gray-900">
+            Learn more
+            <span aria-hidden="true">→</span>
+          </Link>
+        </div>
+      </div>
+    </div>
+  )
+}
+

--- a/src/pages/Pricing.jsx
+++ b/src/pages/Pricing.jsx
@@ -1,0 +1,24 @@
+import Header from '../components/Header'
+import Footer from '../components/Footer'
+import PricingCTA from '../components/PricingCTA'
+
+export default function Pricing() {
+  return (
+    <>
+      <Header />
+      <section className="bg-white py-20 px-6 text-center">
+        <div className="mx-auto max-w-3xl">
+          <h1 className="text-4xl font-semibold tracking-tight text-gray-900 sm:text-5xl">
+            Pricing
+          </h1>
+          <p className="mt-6 text-lg text-gray-600">
+            Choose the plan that best suits your campaign goals.
+          </p>
+        </div>
+      </section>
+      <PricingCTA />
+      <Footer />
+    </>
+  )
+}
+


### PR DESCRIPTION
## Summary
- add PricingCTA component with paraphrased call to action
- create Pricing page and route, inserting new CTA before footer
- trim extra space below footer

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a2c1a12274832e83febce758ff8012