### PR TITLE
feat: add pricing CTA component

### DIFF
--- a/src/components/PricingCTA.jsx
+++ b/src/components/PricingCTA.jsx
@@ -1,0 +1,27 @@
+import { Link } from 'react-router-dom'
+
+export default function PricingCTA() {
+  return (
+    <div className="bg-indigo-100">
+      <div className="mx-auto max-w-7xl px-6 py-24 sm:py-32 lg:flex lg:items-center lg:justify-between lg:px-8">
+        <h2 className="max-w-2xl text-4xl font-semibold tracking-tight text-gray-900 sm:text-5xl">
+          Outdoor ads, minus the overload.
+          <br />
+          Catch eyes while we handle the rest.
+        </h2>
+        <div className="mt-10 flex items-center gap-x-6 lg:mt-0 lg:shrink-0">
+          <Link
+            to="/sign-up"
+            className="rounded-md bg-indigo-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-xs hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+          >
+            Get started
+          </Link>
+          <Link to="/about" className="text-sm/6 font-semibold text-gray-900">
+            Learn more <span aria-hidden="true">→</span>
+          </Link>
+        </div>
+      </div>
+    </div>
+  )
+}
+

--- a/src/pages/Pricing.jsx
+++ b/src/pages/Pricing.jsx
@@ -10,11 +10,12 @@ import {
 import HeroHeader from '../components/HeroHeader'
 import Header from '../components/Header'
 import Footer from '../components/Footer'
+import PricingCTA from '../components/PricingCTA'
 
 
 export default function Pricing() {
   return (
-    <div className="bg-white py-24 sm:py-32">
+    <div className="bg-white pt-24 sm:pt-32">
       <HeroHeader />
       <Header />
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
@@ -119,6 +120,7 @@ export default function Pricing() {
           </div>
         </div>
       </div>
+      <PricingCTA />
       <Footer />
     </div>
   )


### PR DESCRIPTION
## Summary
- add pricing call-to-action component with paraphrased messaging
- insert pricing CTA before footer on pricing page and remove extra bottom spacing

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Missing script: "lint")

------
https://chatgpt.com/codex/tasks/task_e_68a2c6fdb3dc832e99bceeaad1fddc19