### PR TITLE
Use sticky HeroHeader across pages

### DIFF
--- a/src/components/HeroHeader.jsx
+++ b/src/components/HeroHeader.jsx
@@ -17,7 +17,7 @@ export default function HeroHeader() {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
 
   return (
-    <header className="absolute inset-x-0 top-0 z-50">
+    <header className="fixed inset-x-0 top-0 z-50 bg-transparent">
       <nav aria-label="Global" className="flex items-center justify-between p-6 lg:px-8">
         <div className="flex lg:flex-1">
           <Link to="/" className="-m-1.5 p-1.5">

--- a/src/pages/About.jsx
+++ b/src/pages/About.jsx
@@ -11,7 +11,6 @@ import {
   UserGroupIcon,
 } from '@heroicons/react/20/solid'
 import HeroHeader from '../components/HeroHeader'
-import Header from '../components/Header'
 import Footer from '../components/Footer'
 import OurLeadershipTeam from '../components/OurLeadershipTeam.jsx'
 
@@ -77,7 +76,6 @@ export default function About() {
     <div className="bg-white">
       {/* Header */}
       <HeroHeader />
-      <Header />
 
       <main className="relative isolate">
         {/* Background blob */}

--- a/src/pages/BlogPost.jsx
+++ b/src/pages/BlogPost.jsx
@@ -1,6 +1,6 @@
 import { useParams } from 'react-router-dom';
 import { posts } from '../data/blogs';
-import Header from '../components/Header';
+import HeroHeader from '../components/HeroHeader';
 import Footer from '../components/Footer';
 
 export default function BlogPost() {
@@ -10,7 +10,7 @@ export default function BlogPost() {
   if (!post) {
     return (
       <>
-        <Header staticHeader />
+        <HeroHeader />
         <div className="mx-auto max-w-7xl px-6 py-24 text-center">
           <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">Blog not found</h1>
         </div>
@@ -21,7 +21,7 @@ export default function BlogPost() {
 
   return (
     <>
-      <Header staticHeader />
+      <HeroHeader />
       <article
         className="
           mx-auto max-w-3xl

--- a/src/pages/Blogs.jsx
+++ b/src/pages/Blogs.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Header from '../components/Header';
+import HeroHeader from '../components/HeroHeader';
 import Footer from '../components/Footer';
 import BlogFlyer from '../components/BlogFlyer';
 import { posts } from '../data/blogs';
@@ -7,7 +7,7 @@ import { posts } from '../data/blogs';
 export default function Blogs() {
   return (
     <>
-      <Header staticHeader />
+      <HeroHeader />
       <BlogFlyer posts={posts} />
       <Footer />
     </>

--- a/src/pages/Contact.jsx
+++ b/src/pages/Contact.jsx
@@ -1,4 +1,4 @@
-import Header from '../components/Header';
+import HeroHeader from '../components/HeroHeader';
 import Footer from '../components/Footer';
 import Card from '../components/Card';
 import { BuildingOffice2Icon, EnvelopeIcon, PhoneIcon } from '@heroicons/react/24/outline';
@@ -6,7 +6,7 @@ import { BuildingOffice2Icon, EnvelopeIcon, PhoneIcon } from '@heroicons/react/2
 export default function Contact() {
   return (
     <>
-      <Header staticHeader />
+      <HeroHeader />
       <main className="bg-white">
         {/* Outer spacing so it's not too close to the header */}
         <section className="pt-10 sm:pt-14 lg:pt-16 pb-12">

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,5 +1,4 @@
 // pages/Home.jsx
-import Header from '../components/Header';
 import HeroSection from '../components/HeroSection';
 import HowItWorks from '../components/HowItWorks';
 import Integrations from '../components/Integrations';
@@ -15,7 +14,6 @@ import Intercom from '../components/intercom-landing';
 export default function Home() {
   return (
     <>
-      <Header />
       <HeroSection />
       <HowItWorks />
       <Integrations />

--- a/src/pages/Press.jsx
+++ b/src/pages/Press.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import Header from '../components/Header';
+import HeroHeader from '../components/HeroHeader';
 import Footer from '../components/Footer';
 
 export default function Press() {
   return (
     <>
-      <Header staticHeader />
+      <HeroHeader />
       <main className="mx-auto max-w-4xl px-6 py-16">
         <h1 className="text-3xl font-bold mb-4">Press</h1>
         <p className="text-gray-600">Read the latest news about BoardBid.ai.</p>

--- a/src/pages/Pricing.jsx
+++ b/src/pages/Pricing.jsx
@@ -8,7 +8,6 @@ import {
   MapPinIcon,
 } from '@heroicons/react/24/outline'
 import HeroHeader from '../components/HeroHeader'
-import Header from '../components/Header'
 import Footer from '../components/Footer'
 import PricingCTA from '../components/PricingCTA'
 
@@ -16,7 +15,6 @@ export default function Pricing() {
   return (
     <div className="bg-white pt-24 sm:pt-32">
       <HeroHeader />
-      <Header />
 
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
         {/* Headline */}

--- a/src/pages/Support.jsx
+++ b/src/pages/Support.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import Header from '../components/Header';
+import HeroHeader from '../components/HeroHeader';
 import Footer from '../components/Footer';
 
 export default function Support() {
   return (
     <>
-      <Header staticHeader />
+      <HeroHeader />
       <main className="mx-auto max-w-4xl px-6 py-16">
         <h1 className="text-3xl font-bold mb-4">Support</h1>
         <p className="text-gray-600">Submit a ticket and we'll get back to you shortly.</p>


### PR DESCRIPTION
## Summary
- replace old Header component with HeroHeader in public pages
- make HeroHeader fixed with a transparent background so it stays visible while scrolling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a2f33fb128832e9629f4f04d013834