### PR TITLE
feat: make home banner sticky at bottom

### DIFF
--- a/src/components/HomeBanner.jsx
+++ b/src/components/HomeBanner.jsx
@@ -2,7 +2,7 @@ import { XMarkIcon } from '@heroicons/react/20/solid'
 
 export default function Banner() {
   return (
-    <div className="relative isolate flex items-center gap-x-6 overflow-hidden bg-gray-50 px-6 py-2.5 sm:px-3.5 sm:before:flex-1">
+    <div className="fixed inset-x-0 bottom-0 z-50 isolate flex items-center gap-x-6 overflow-hidden bg-gray-50 px-6 py-2.5 sm:px-3.5 sm:before:flex-1">
       <div
         aria-hidden="true"
         className="absolute top-1/2 left-[max(-7rem,calc(50%-52rem))] -z-10 -translate-y-1/2 transform-gpu blur-2xl"


### PR DESCRIPTION
## Summary
- position home banner fixed at bottom to stay visible when scrolling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a309f805c8832e907774b95528ad78