### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/src/components/HomeBanner.jsx
+++ b/src/components/HomeBanner.jsx
@@ -2,7 +2,7 @@ import { XMarkIcon } from '@heroicons/react/20/solid'
 
 export default function Banner() {
   return (
-    <div className="fixed inset-x-0 bottom-0 z-50 isolate flex items-center gap-x-6 overflow-hidden bg-gray-50 px-6 py-2.5 sm:px-3.5 sm:before:flex-1">
+    <div className="hidden sm:fixed sm:inset-x-0 sm:bottom-0 sm:z-50 sm:isolate sm:flex sm:items-center sm:gap-x-6 overflow-hidden bg-gray-50 px-6 py-2.5 sm:px-3.5 sm:before:flex-1">
       <div
         aria-hidden="true"
         className="absolute top-1/2 left-[max(-7rem,calc(50%-52rem))] -z-10 -translate-y-1/2 transform-gpu blur-2xl"

--- a/src/index.css
+++ b/src/index.css
@@ -5,7 +5,6 @@
 
 html,
 body {
-  overflow-x: hidden;
   font-family: 'Inter', sans-serif;
 }
 

--- a/src/pages/About.jsx
+++ b/src/pages/About.jsx
@@ -88,7 +88,7 @@ export default function About() {
               clipPath:
                 'polygon(73.6% 51.7%, 91.7% 11.8%, 100% 46.4%, 97.4% 82.2%, 92.5% 84.9%, 75.7% 64%, 55.3% 47.5%, 46.5% 49.4%, 45% 62.9%, 50.3% 87.2%, 21.3% 64.1%, 0.1% 100%, 5.4% 51.1%, 21.4% 63.9%, 58.9% 0.2%, 73.6% 51.7%)',
             }}
-            className="aspect-[1108/632] w-[277px] flex-none bg-gradient-to-r from-[#80caff] to-[#288dcf] opacity-25"
+            className="hidden sm:block aspect-[1108/632] sm:w-[277px] flex-none bg-gradient-to-r from-[#80caff] to-[#288dcf] opacity-25"
           />
         </div>
 
@@ -201,10 +201,10 @@ export default function About() {
                 clipPath:
                   'polygon(73.6% 51.7%, 91.7% 11.8%, 100% 46.4%, 97.4% 82.2%, 92.5% 84.9%, 75.7% 64%, 55.3% 47.5%, 46.5% 49.4%, 45% 62.9%, 50.3% 87.2%, 21.3% 64.1%, 0.1% 100%, 5.4% 51.1%, 21.4% 63.9%, 58.9% 0.2%, 73.6% 51.7%)',
               }}
-              className="aspect-[1318/752] w-[329.5px] flex-none bg-gradient-to-r from-[#9fd6fc] to-[#288dcf] opacity-40"
-            />
-          </div>
+            className="hidden sm:block aspect-[1318/752] sm:w-[329.5px] flex-none bg-gradient-to-r from-[#9fd6fc] to-[#288dcf] opacity-40"
+          />
         </div>
+      </div>
       </main>
 
       {/* Footer */}


### PR DESCRIPTION
## Summary
- Remove global `overflow-x: hidden` to prevent content clipping on narrow screens
- Hide fixed footer banner on small viewports
- Hide decorative background blobs on the About page for mobile devices

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a3299d2a8c832e951d5edb07f41ace