### PR TITLE
Fix Manage Creatives list parsing

### DIFF
--- a/src/pages/UploadCreative.jsx
+++ b/src/pages/UploadCreative.jsx
@@ -33,7 +33,17 @@ export default function UploadCreative() {
       const res = await fetch(`${API_URL}/users/${user.id}/creatives`);
       if (res.ok) {
         const data = await res.json();
-        const arr = Array.isArray(data) ? data : data.creatives || [];
+        let arr = [];
+        if (Array.isArray(data)) {
+          arr = data;
+        } else if (Array.isArray(data.creatives)) {
+          arr = data.creatives;
+        } else if (data.creatives && typeof data.creatives === 'object') {
+          arr = Object.entries(data.creatives).map(([filename, value]) => ({
+            filename,
+            url: typeof value === 'string' ? value : value.url || value.public_url || ''
+          }));
+        }
         setCreatives(arr);
       }
     } catch (err) {


### PR DESCRIPTION
## Summary
- Make Manage Creatives robust to different API response shapes so URLs display correctly

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a58707499c832e90ccf8235b0dc7c6