### PR TITLE
Fix upload creative close button leading to blank page

### DIFF
--- a/src/components/CreativeUploadDrawer.jsx
+++ b/src/components/CreativeUploadDrawer.jsx
@@ -123,9 +123,9 @@ export default function CreativeUploadDrawer({ open, onClose, onUploaded }) {
   return (
     <Drawer
       open={open}
-      onClose={() => {
+      onClose={(value) => {
         resetState();
-        onClose?.();
+        onClose?.(value);
       }}
       title={drawerTitle}
     >


### PR DESCRIPTION
## Summary
- Forward close-state value in CreativeUploadDrawer so closing the drawer resets properly without navigation to blank page.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5baf0f3d8832ea5e99ef0e1c59562