### PR TITLE
feat: add hero icon to upload creative button

### DIFF
--- a/src/components/PageHeader.jsx
+++ b/src/components/PageHeader.jsx
@@ -56,21 +56,31 @@ export default function PageHeader({
         <div className="mt-4 flex flex-wrap gap-2 md:mt-0 md:ml-4">
           {rightSlot
             ? rightSlot
-            : actions.map(({ label, to, onClick, variant = "secondary" }, i) => {
-                const cls =
-                  "inline-flex items-center rounded-md px-3 py-2 text-sm font-semibold " +
-                  "focus-visible:outline-2 focus-visible:outline-offset-2 " +
-                  (variants[variant] || variants.secondary);
-                return to ? (
-                  <Link key={i} to={to} className={cls}>
-                    {label}
-                  </Link>
-                ) : (
-                  <button key={i} type="button" onClick={onClick} className={cls}>
-                    {label}
-                  </button>
-                );
-              })}
+            : actions.map(
+                ({ label, to, onClick, variant = "secondary", icon: Icon }, i) => {
+                  const cls =
+                    "inline-flex items-center rounded-md px-3 py-2 text-sm font-semibold " +
+                    "focus-visible:outline-2 focus-visible:outline-offset-2 " +
+                    (variants[variant] || variants.secondary);
+
+                  const content = (
+                    <>
+                      {Icon && <Icon className="mr-1.5 h-5 w-5" aria-hidden="true" />}
+                      {label}
+                    </>
+                  );
+
+                  return to ? (
+                    <Link key={i} to={to} className={cls}>
+                      {content}
+                    </Link>
+                  ) : (
+                    <button key={i} type="button" onClick={onClick} className={cls}>
+                      {content}
+                    </button>
+                  );
+                }
+              )}
         </div>
       </div>
     </div>

--- a/src/pages/UploadCreative.jsx
+++ b/src/pages/UploadCreative.jsx
@@ -1,7 +1,14 @@
 // src/pages/UploadCreative.jsx
 import React, { useEffect, useState, useRef } from 'react';
 import { useUser } from '@clerk/clerk-react';
-import { TrashIcon, EyeIcon, LinkIcon, PhotoIcon, CheckCircleIcon } from '@heroicons/react/24/solid';
+import {
+  TrashIcon,
+  EyeIcon,
+  LinkIcon,
+  PhotoIcon,
+  CheckCircleIcon,
+  ArrowUpTrayIcon,
+} from '@heroicons/react/24/solid';
 import InternalLayout from '../layout/InternalLayout';
 import PageHeader from '../components/PageHeader';
 import Card from '../components/Card';
@@ -100,7 +107,12 @@ export default function UploadCreative() {
       <PageHeader
         title="Manage Creatives"
         actions={[
-          { label: 'Upload Creative', variant: 'primary', onClick: () => setDrawerOpen(true) },
+          {
+            label: 'Upload Creative',
+            variant: 'primary',
+            onClick: () => setDrawerOpen(true),
+            icon: ArrowUpTrayIcon,
+          },
         ]}
       />
 


### PR DESCRIPTION
## Summary
- allow `PageHeader` actions to display optional icon components
- show ArrowUpTray icon on the Manage Creatives "Upload Creative" button

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5d9faa324832eb3a93b1f4ecda62f