### PR TITLE
fix: send user id to campaign form

### DIFF
--- a/src/pages/NewCampaignPage.jsx
+++ b/src/pages/NewCampaignPage.jsx
@@ -1,6 +1,5 @@
-import { useUser } from "@clerk/clerk-react";   // ✅ import from Clerk
+import { useUser } from "@clerk/clerk-react";
 import InternalLayout from "../layout/InternalLayout";
-import PageHeader from "../components/PageHeader";
 import Card from "../components/Card";
 
 export default function NewCampaignPage() {
@@ -24,7 +23,9 @@ export default function NewCampaignPage() {
       <Card title="New Campaign Form">
         <iframe
           className="w-full h-[1000px]"
-          src={`https://forms.fillout.com/t/umZFxzNKgUus?user_id=${userId}`}
+          src={`https://boardbid.fillout.com/t/umZFxzNKgUus?hideCookieBanner=true&user_id=${encodeURIComponent(
+            userId
+          )}`}
           frameBorder="0"
           style={{ background: "transparent", border: "none" }}
           allowFullScreen


### PR DESCRIPTION
## Summary
- pass logged-in user's ID to the Fillout campaign form

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a66d1e374c832e99dfb4eb43cfa9a7