### PR TITLE
Add embedded video to pricing page

### DIFF
--- a/src/components/PricingVideo.jsx
+++ b/src/components/PricingVideo.jsx
@@ -1,0 +1,16 @@
+export default function PricingVideo() {
+  return (
+    <div className="mx-auto mt-16 max-w-7xl px-6 lg:px-8">
+      <div className="relative overflow-hidden rounded-lg aspect-video">
+        <iframe
+          src="https://www.youtube.com/embed/VzCY-NefSQE?rel=0&modestbranding=1&playsinline=1&showinfo=0"
+          title="BoardBid.ai Video"
+          allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+          allowFullScreen
+          loading="lazy"
+          className="absolute inset-0 h-full w-full border-0"
+        ></iframe>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/Pricing.jsx
+++ b/src/pages/Pricing.jsx
@@ -10,6 +10,7 @@ import {
 import HeroHeader from '../components/HeroHeader'
 import Footer from '../components/Footer'
 import PricingCTA from '../components/PricingCTA'
+import PricingVideo from '../components/PricingVideo'
 
 export default function Pricing() {
   return (
@@ -151,6 +152,7 @@ export default function Pricing() {
         </div>
       </div>
 
+      <PricingVideo />
       <PricingCTA />
       <Footer />
     </div>


### PR DESCRIPTION
## Summary
- add `PricingVideo` component for YouTube embed
- insert video component above CTA on pricing page

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a68c0d06e8832ea85e126c4b687cf9