### PR TITLE
Fetch campaigns from API with details and quotes tabs

### DIFF
--- a/src/pages/CampaignDetail.jsx
+++ b/src/pages/CampaignDetail.jsx
@@ -3,6 +3,8 @@ import { NavLink, Routes, Route, Navigate, useParams } from 'react-router-dom';
 import CampaignCreative from './CampaignCreative';
 import CampaignProgress from './CampaignProgress';
 import CampaignReports from './CampaignReports';
+import CampaignInfo from './CampaignInfo';
+import CampaignQuotes from './CampaignQuotes';
 
 function classNames(...classes) {
   return classes.filter(Boolean).join(' ');
@@ -11,7 +13,9 @@ function classNames(...classes) {
 export default function CampaignDetail() {
   const { id } = useParams();
   const navigation = [
+    { name: 'Details', to: 'details' },
     { name: 'Creative', to: 'creative' },
+    { name: 'Quotes', to: 'quotes' },
     { name: 'View Campaign Progress', to: 'progress' },
     { name: 'Reports', to: 'reports' },
   ];
@@ -46,10 +50,12 @@ export default function CampaignDetail() {
         {/* Child routes render their own Card — don’t wrap in another card here */}
         <div className="py-5">
           <Routes>
+            <Route path="details" element={<CampaignInfo />} />
             <Route path="creative" element={<CampaignCreative />} />
+            <Route path="quotes" element={<CampaignQuotes />} />
             <Route path="progress" element={<CampaignProgress />} />
             <Route path="reports" element={<CampaignReports />} />
-            <Route index element={<Navigate to={`/campaigns/${id}/creative`} replace />} />
+            <Route index element={<Navigate to={`/campaigns/${id}/details`} replace />} />
           </Routes>
         </div>
       </div>

--- a/src/pages/CampaignInfo.jsx
+++ b/src/pages/CampaignInfo.jsx
@@ -1,0 +1,57 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { useUser } from '@clerk/clerk-react';
+
+const API_URL = import.meta.env.VITE_API_URL;
+
+export default function CampaignInfo() {
+  const { id } = useParams();
+  const { user } = useUser();
+  const [campaign, setCampaign] = useState(null);
+
+  useEffect(() => {
+    if (!user) return;
+
+    const fetchCampaign = async () => {
+      try {
+        const res = await fetch(`${API_URL}/users/${user.id}/campaigns`);
+        if (!res.ok) return;
+        const data = await res.json();
+        const found = (data.campaigns || []).find((c) => c.id === id);
+        setCampaign(found);
+      } catch (err) {
+        console.error('Failed to load campaign', err);
+      }
+    };
+
+    fetchCampaign();
+  }, [user, id]);
+
+  if (!campaign) {
+    return <p className="text-gray-500">No details available.</p>;
+  }
+
+  const fields = [
+    { label: 'Company Name', value: campaign.company_name },
+    { label: 'Campaign Type', value: campaign.campaign_type?.join(', ') },
+    { label: 'Industry', value: campaign.industry },
+    { label: 'Goals', value: campaign.campaign_goals?.join(', ') },
+    { label: 'Budget', value: campaign.ooh_budget_range },
+    { label: 'Start Date', value: campaign.campaign_start_date },
+    { label: 'End Date', value: campaign.campaign_end_date },
+    { label: 'Status', value: campaign.status },
+  ];
+
+  return (
+    <div className="rounded-xl bg-white p-6 shadow-sm dark:bg-gray-800 dark:text-white">
+      <dl className="divide-y divide-gray-100 dark:divide-gray-700">
+        {fields.map((field) => (
+          <div key={field.label} className="flex justify-between gap-x-4 py-3">
+            <dt className="text-gray-500 dark:text-gray-400">{field.label}</dt>
+            <dd className="text-gray-900 dark:text-gray-100">{field.value || '-'}</dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  );
+}

--- a/src/pages/CampaignQuotes.jsx
+++ b/src/pages/CampaignQuotes.jsx
@@ -1,0 +1,13 @@
+export default function CampaignQuotes() {
+  return (
+    <div className="rounded-xl bg-white p-6 shadow-sm text-center dark:bg-gray-800 dark:text-white">
+      <p className="mb-4 text-gray-700 dark:text-gray-300">Quotes will appear here.</p>
+      <button
+        type="button"
+        className="rounded-md bg-blue-600 px-4 py-2 text-white shadow-sm hover:bg-blue-500"
+      >
+        Pay with Strio
+      </button>
+    </div>
+  );
+}

--- a/src/pages/Campaigns.jsx
+++ b/src/pages/Campaigns.jsx
@@ -3,97 +3,108 @@ import PageHeader from '../components/PageHeader';
 import { Menu, MenuButton, MenuItem, MenuItems } from '@headlessui/react';
 import { EllipsisHorizontalIcon } from '@heroicons/react/20/solid';
 import { useNavigate } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { useUser } from '@clerk/clerk-react';
 
-const clients = [
-  {
-    id: 1,
-    name: 'Nation Wide Billboards',
-    imageUrl: 'https://ik.imagekit.io/boardbid/faviconBB.svg?updatedAt=1754589379642',
-    lastInvoice: { date: 'August 21, 2025', dateTime: '2025-08-21', amount: '$20,000.00', status: 'Paid' },
-  },
-];
+const API_URL = import.meta.env.VITE_API_URL;
 
 export default function Campaigns() {
   const navigate = useNavigate();
+  const { user } = useUser();
+  const [campaigns, setCampaigns] = useState([]);
+
+  useEffect(() => {
+    if (!user) return;
+
+    const loadCampaigns = async () => {
+      try {
+        const res = await fetch(`${API_URL}/users/${user.id}/campaigns`);
+        if (!res.ok) {
+          setCampaigns([]);
+          return;
+        }
+        const data = await res.json();
+        setCampaigns(Array.isArray(data?.campaigns) ? data.campaigns : []);
+      } catch (err) {
+        console.error('Failed to fetch campaigns', err);
+        setCampaigns([]);
+      }
+    };
+
+    loadCampaigns();
+  }, [user]);
 
   return (
     <InternalLayout>
       <PageHeader title="My Campaigns" />
-      <ul role="list" className="grid grid-cols-1 gap-x-6 gap-y-8 lg:grid-cols-3 xl:gap-x-8">
-        {clients.map((client) => (
-          <li
-            key={client.id}
-            onClick={() => navigate(`/campaigns/${client.id}`)}
-            className="overflow-hidden rounded-xl outline outline-gray-200 cursor-pointer dark:-outline-offset-1 dark:outline-white/10"
-          >
-            <div className="flex items-center gap-x-4 border-b border-gray-900/5 bg-gray-50 p-6 dark:border-white/10 dark:bg-gray-800/50">
-              <img
-                alt={client.name}
-                src={client.imageUrl}
-                className="size-12 flex-none rounded-lg bg-white object-cover ring-1 ring-gray-900/10 dark:bg-gray-700 dark:ring-white/10"
-              />
-              <div className="text-sm/6 font-medium text-gray-900 dark:text-white">{client.name}</div>
-              <Menu as="div" className="relative ml-auto" onClick={(e) => e.stopPropagation()}>
-                <MenuButton className="relative block text-gray-400 hover:text-gray-500 dark:text-gray-400 dark:hover:text-white">
-                  <span className="absolute -inset-2.5" />
-                  <span className="sr-only">Open options</span>
-                  <EllipsisHorizontalIcon aria-hidden="true" className="size-5" />
-                </MenuButton>
-                <MenuItems
-                  transition
-                  className="absolute right-0 z-10 mt-0.5 w-32 origin-top-right rounded-md bg-white py-2 shadow-lg outline-1 outline-gray-900/5 transition data-closed:scale-95 data-closed:transform data-closed:opacity-0 data-enter:duration-100 data-enter:ease-out data-leave:duration-75 data-leave:ease-in dark:bg-gray-800 dark:shadow-none dark:-outline-offset-1 dark:outline-white/10"
-                >
-                  <MenuItem>
-                    <a
-                      href="#"
-                      className="block px-3 py-1 text-sm/6 text-gray-900 data-focus:bg-gray-50 data-focus:outline-hidden dark:text-white dark:data-focus:bg-white/5"
-                    >
-                      View<span className="sr-only">, {client.name}</span>
-                    </a>
-                  </MenuItem>
-                  <MenuItem>
-                    <a
-                      href="#"
-                      className="block px-3 py-1 text-sm/6 text-gray-900 data-focus:bg-gray-50 data-focus:outline-hidden dark:text-white dark:data-focus:bg-white/5"
-                    >
-                      Edit<span className="sr-only">, {client.name}</span>
-                    </a>
-                  </MenuItem>
-                </MenuItems>
-              </Menu>
-            </div>
-            <dl className="-my-3 divide-y divide-gray-100 px-6 py-4 text-sm/6 dark:divide-white/10">
-              <div className="flex justify-between gap-x-4 py-3">
-                <dt className="text-gray-500 dark:text-gray-400">Last invoice</dt>
-                <dd className="text-gray-700 dark:text-gray-300">
-                  <time dateTime={client.lastInvoice.dateTime}>{client.lastInvoice.date}</time>
-                </dd>
+      {campaigns.length === 0 ? (
+        <p className="text-center text-gray-500">No campaigns found.</p>
+      ) : (
+        <ul role="list" className="grid grid-cols-1 gap-x-6 gap-y-8 lg:grid-cols-3 xl:gap-x-8">
+          {campaigns.map((campaign) => (
+            <li
+              key={campaign.id}
+              onClick={() => navigate(`/campaigns/${campaign.id}`)}
+              className="overflow-hidden rounded-xl outline outline-gray-200 cursor-pointer dark:-outline-offset-1 dark:outline-white/10"
+            >
+              <div className="flex items-center gap-x-4 border-b border-gray-900/5 bg-gray-50 p-6 dark:border-white/10 dark:bg-gray-800/50">
+                <img
+                  alt={campaign.company_name}
+                  src="https://ik.imagekit.io/boardbid/faviconBB.svg?updatedAt=1754589379642"
+                  className="size-12 flex-none rounded-lg bg-white object-cover ring-1 ring-gray-900/10 dark:bg-gray-700 dark:ring-white/10"
+                />
+                <div className="text-sm/6 font-medium text-gray-900 dark:text-white">{campaign.company_name}</div>
+                <Menu as="div" className="relative ml-auto" onClick={(e) => e.stopPropagation()}>
+                  <MenuButton className="relative block text-gray-400 hover:text-gray-500 dark:text-gray-400 dark:hover:text-white">
+                    <span className="absolute -inset-2.5" />
+                    <span className="sr-only">Open options</span>
+                    <EllipsisHorizontalIcon aria-hidden="true" className="size-5" />
+                  </MenuButton>
+                  <MenuItems
+                    transition
+                    className="absolute right-0 z-10 mt-0.5 w-32 origin-top-right rounded-md bg-white py-2 shadow-lg outline-1 outline-gray-900/5 transition data-closed:scale-95 data-closed:transform data-closed:opacity-0 data-enter:duration-100 data-enter:ease-out data-leave:duration-75 data-leave:ease-in dark:bg-gray-800 dark:shadow-none dark:-outline-offset-1 dark:outline-white/10"
+                  >
+                    <MenuItem>
+                      <a
+                        href="#"
+                        className="block px-3 py-1 text-sm/6 text-gray-900 data-focus:bg-gray-50 data-focus:outline-hidden dark:text-white dark:data-focus:bg-white/5"
+                      >
+                        View<span className="sr-only">, {campaign.company_name}</span>
+                      </a>
+                    </MenuItem>
+                    <MenuItem>
+                      <a
+                        href="#"
+                        className="block px-3 py-1 text-sm/6 text-gray-900 data-focus:bg-gray-50 data-focus:outline-hidden dark:text-white dark:data-focus:bg-white/5"
+                      >
+                        Edit<span className="sr-only">, {campaign.company_name}</span>
+                      </a>
+                    </MenuItem>
+                  </MenuItems>
+                </Menu>
               </div>
-              <div className="flex justify-between gap-x-4 py-3">
-                <dt className="text-gray-500 dark:text-gray-400">Amount</dt>
-                <dd className="flex items-start gap-x-2">
-                  <div className="font-medium text-gray-900 dark:text-white">{client.lastInvoice.amount}</div>
-                  {client.lastInvoice.status == 'Paid' ? (
-                    <div className="rounded-md bg-green-50 px-2 py-1 text-xs font-medium text-green-700 ring-1 ring-green-600/20 ring-inset dark:bg-green-500/10 dark:text-green-500 dark:ring-green-500/10">
-                      {client.lastInvoice.status}
-                    </div>
-                  ) : null}
-                  {client.lastInvoice.status == 'Withdraw' ? (
-                    <div className="rounded-md bg-gray-50 px-2 py-1 text-xs font-medium text-gray-600 ring-1 ring-gray-500/10 ring-inset dark:bg-white/5 dark:text-gray-400 dark:ring-white/10">
-                      {client.lastInvoice.status}
-                    </div>
-                  ) : null}
-                  {client.lastInvoice.status == 'Overdue' ? (
-                    <div className="rounded-md bg-red-50 px-2 py-1 text-xs font-medium text-red-700 ring-1 ring-red-600/10 ring-inset dark:bg-red-500/10 dark:text-red-400 dark:ring-red-500/10">
-                      {client.lastInvoice.status}
-                    </div>
-                  ) : null}
-                </dd>
-              </div>
-            </dl>
-          </li>
-        ))}
-      </ul>
+              <dl className="-my-3 divide-y divide-gray-100 px-6 py-4 text-sm/6 dark:divide-white/10">
+                <div className="flex justify-between gap-x-4 py-3">
+                  <dt className="text-gray-500 dark:text-gray-400">Start</dt>
+                  <dd className="text-gray-700 dark:text-gray-300">
+                    <time dateTime={campaign.campaign_start_date}>{campaign.campaign_start_date}</time>
+                  </dd>
+                </div>
+                <div className="flex justify-between gap-x-4 py-3">
+                  <dt className="text-gray-500 dark:text-gray-400">End</dt>
+                  <dd className="text-gray-700 dark:text-gray-300">
+                    <time dateTime={campaign.campaign_end_date}>{campaign.campaign_end_date}</time>
+                  </dd>
+                </div>
+                <div className="flex justify-between gap-x-4 py-3">
+                  <dt className="text-gray-500 dark:text-gray-400">Status</dt>
+                  <dd className="text-gray-700 dark:text-gray-300">{campaign.status}</dd>
+                </div>
+              </dl>
+            </li>
+          ))}
+        </ul>
+      )}
     </InternalLayout>
   );
 }


### PR DESCRIPTION
## Summary
- load campaigns from backend API and display as cards
- add campaign details and quotes tabs with placeholders

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8ad284af4832ea59f1d3e06f81ced