### PR TITLE
feat: add loading animation to campaigns page

### DIFF
--- a/src/pages/CampaignInfo.jsx
+++ b/src/pages/CampaignInfo.jsx
@@ -50,16 +50,34 @@ export default function CampaignInfo() {
     return <p className="text-gray-500">No details available.</p>;
   }
 
-  const fields = [
-    { label: 'Company Name', value: campaign.company_name },
-    { label: 'Campaign Type', value: campaign.campaign_type?.join(', ') },
-    { label: 'Industry', value: campaign.industry },
-    { label: 'Goals', value: campaign.campaign_goals?.join(', ') },
-    { label: 'Budget', value: campaign.ooh_budget_range },
-    { label: 'Start Date', value: campaign.campaign_start_date },
-    { label: 'End Date', value: campaign.campaign_end_date },
-    { label: 'Status', value: campaign.status },
-  ];
+  const labelMap = {
+    company_name: 'Company Name',
+    campaign_type: 'Campaign Type',
+    industry: 'Industry',
+    campaign_goals: 'Goals',
+    ooh_budget_range: 'Budget',
+    campaign_start_date: 'Start Date',
+    campaign_end_date: 'End Date',
+    status: 'Status',
+  };
+
+  const fields = Object.entries(campaign)
+    .filter(
+      ([key, value]) =>
+        key !== 'attachments' &&
+        value !== null &&
+        value !== undefined &&
+        value !== '' &&
+        (!Array.isArray(value) || value.length > 0)
+    )
+    .map(([key, value]) => ({
+      label:
+        labelMap[key] ||
+        key
+          .replace(/_/g, ' ')
+          .replace(/\b\w/g, (c) => c.toUpperCase()),
+      value: Array.isArray(value) ? value.join(', ') : value,
+    }));
 
   return (
     <div className="overflow-hidden bg-white shadow-sm sm:rounded-lg">

--- a/src/pages/Campaigns.jsx
+++ b/src/pages/Campaigns.jsx
@@ -5,6 +5,8 @@ import { EllipsisHorizontalIcon } from '@heroicons/react/20/solid';
 import { useNavigate } from 'react-router-dom';
 import { useEffect, useState } from 'react';
 import { useUser } from '@clerk/clerk-react';
+import Lottie from 'lottie-react';
+import loadingAnim from '../assets/loading.json';
 
 const API_URL = import.meta.env.VITE_API_URL;
 
@@ -12,11 +14,13 @@ export default function Campaigns() {
   const navigate = useNavigate();
   const { user } = useUser();
   const [campaigns, setCampaigns] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     if (!user) return;
 
     const loadCampaigns = async () => {
+      setIsLoading(true);
       try {
         const res = await fetch(`${API_URL}/users/${user.id}/campaigns`);
         if (!res.ok) {
@@ -28,6 +32,8 @@ export default function Campaigns() {
       } catch (err) {
         console.error('Failed to fetch campaigns', err);
         setCampaigns([]);
+      } finally {
+        setIsLoading(false);
       }
     };
 
@@ -37,7 +43,13 @@ export default function Campaigns() {
   return (
     <InternalLayout>
       <PageHeader title="My Campaigns" />
-      {campaigns.length === 0 ? (
+      {isLoading ? (
+        <div className="flex h-48 items-center justify-center">
+          <div className="h-24 w-24">
+            <Lottie animationData={loadingAnim} loop autoplay />
+          </div>
+        </div>
+      ) : campaigns.length === 0 ? (
         <p className="text-center text-gray-500">No campaigns found.</p>
       ) : (
         <ul role="list" className="grid grid-cols-1 gap-x-6 gap-y-8 lg:grid-cols-3 xl:gap-x-8">


### PR DESCRIPTION
## Summary
- show Lottie-based loader when fetching campaigns
- render all available campaign details dynamically

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8bd4ededc832eadcdda3921f48d5b