### PR TITLE
fix: handle object fields in campaign info

### DIFF
--- a/src/pages/CampaignInfo.jsx
+++ b/src/pages/CampaignInfo.jsx
@@ -70,14 +70,21 @@ export default function CampaignInfo() {
         value !== '' &&
         (!Array.isArray(value) || value.length > 0)
     )
-    .map(([key, value]) => ({
-      label:
-        labelMap[key] ||
-        key
-          .replace(/_/g, ' ')
-          .replace(/\b\w/g, (c) => c.toUpperCase()),
-      value: Array.isArray(value) ? value.join(', ') : value,
-    }));
+    .map(([key, value]) => {
+      const formattedValue = Array.isArray(value)
+        ? value.join(', ')
+        : typeof value === 'object'
+          ? JSON.stringify(value)
+          : value;
+      return {
+        label:
+          labelMap[key] ||
+          key
+            .replace(/_/g, ' ')
+            .replace(/\b\w/g, (c) => c.toUpperCase()),
+        value: formattedValue,
+      };
+    });
 
   return (
     <div className="overflow-hidden bg-white shadow-sm sm:rounded-lg">


### PR DESCRIPTION
## Summary
- gracefully handle object values when displaying campaign details to avoid React child errors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Rollup failed to resolve import "lottie-react" from "src/pages/UploadCreative.jsx")*
- `npm run lint` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68a8bf8f6ea8832e8d43456e09cf580c