### PR TITLE
Fix new campaign link and update pricing booking link

### DIFF
--- a/src/pages/Campaigns.jsx
+++ b/src/pages/Campaigns.jsx
@@ -2,6 +2,7 @@ import InternalLayout from '../layout/InternalLayout';
 import PageHeader from '../components/PageHeader';
 import { Menu, MenuButton, MenuItem, MenuItems } from '@headlessui/react';
 import { EllipsisHorizontalIcon } from '@heroicons/react/20/solid';
+import { MegaphoneIcon } from '@heroicons/react/24/outline';
 import { useNavigate } from 'react-router-dom';
 import { useEffect, useState } from 'react';
 import { useUser } from '@clerk/clerk-react';
@@ -75,14 +76,14 @@ export default function Campaigns() {
       ) : campaigns.length === 0 ? (
         <div className="mx-auto max-w-3xl rounded-2xl border border-dashed border-gray-300 p-10 text-center dark:border-white/10">
           <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-indigo-600/10">
-            <span className="text-base">📣</span>
+            <MegaphoneIcon className="h-6 w-6 text-indigo-600" />
           </div>
           <h3 className="text-lg font-semibold text-gray-900 dark:text-white">No campaigns yet</h3>
           <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
             Create your first campaign to start planning inventory and tracking status.
           </p>
           <button
-            onClick={() => navigate('/new-campaign')}
+            onClick={() => navigate('/campaign/new')}
             className="mt-5 inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
           >
             New Campaign

--- a/src/pages/Pricing.jsx
+++ b/src/pages/Pricing.jsx
@@ -135,7 +135,9 @@ export default function Pricing() {
 
             <div className="mt-6 flex justify-center">
               <a
-                href="#"
+                href="https://boardbid.fillout.com/kee9zs7Rc3us"
+                target="_blank"
+                rel="noopener noreferrer"
                 className="w-full sm:w-auto rounded-md border border-gray-300 px-5 py-2 text-center text-sm font-semibold text-gray-700 hover:bg-gray-50"
               >
                 Book a Meeting


### PR DESCRIPTION
## Summary
- Use Megaphone hero icon and correct `/campaign/new` path for New Campaign button on My Campaigns
- Point Pricing page "Book a Meeting" CTA to the same Fillout link used for Book a Call

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Rollup failed to resolve import "lottie-react" in UploadCreative.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d18ea154832e859b3ad02b77e621