### PR TITLE
feat: add ops layout

### DIFF
--- a/src/layout/OpsLayout.jsx
+++ b/src/layout/OpsLayout.jsx
@@ -1,0 +1,211 @@
+'use client';
+
+import { Link } from 'react-router-dom';
+import {
+  Disclosure,
+  DisclosureButton,
+  DisclosurePanel,
+  Menu,
+  MenuButton,
+  MenuItem,
+  MenuItems,
+} from '@headlessui/react';
+import { MagnifyingGlassIcon } from '@heroicons/react/20/solid';
+import { Bars3Icon, BellIcon, XMarkIcon } from '@heroicons/react/24/outline';
+
+const user = {
+  name: 'Tom Cook',
+  email: 'tom@example.com',
+  imageUrl:
+    'https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+};
+const navigation = [
+  { name: 'Dashboard', href: '#', current: true },
+  { name: 'Team', href: '#', current: false },
+  { name: 'Projects', href: '#', current: false },
+  { name: 'Calendar', href: '#', current: false },
+  { name: 'Reports', href: '#', current: false },
+];
+const userNavigation = [
+  { name: 'Your profile', href: '#' },
+  { name: 'Settings', href: '#' },
+  { name: 'Sign out', href: '#' },
+];
+
+function classNames(...classes) {
+  return classes.filter(Boolean).join(' ');
+}
+
+export default function OpsLayout({ children }) {
+  return (
+    <div className="min-h-full">
+      <div className="bg-[#288dcf] pb-32">
+        <Disclosure as="nav" className="border-b border-[#d6eaf8]/25 bg-[#288dcf] lg:border-none">
+          <div className="mx-auto max-w-7xl px-2 sm:px-4 lg:px-8">
+            <div className="relative flex h-16 items-center justify-between lg:border-b lg:border-[#d6eaf8]/25">
+              <div className="flex items-center px-2 lg:px-0">
+                <div className="shrink-0">
+                  <img
+                    alt="Your Company"
+                    src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=blue&shade=300"
+                    className="block size-8"
+                  />
+                </div>
+                <div className="hidden lg:ml-10 lg:block">
+                  <div className="flex space-x-4">
+                    {navigation.map((item) => (
+                      <Link
+                        key={item.name}
+                        to={item.href}
+                        aria-current={item.current ? 'page' : undefined}
+                        className={classNames(
+                          item.current
+                            ? 'bg-[#d6eaf8] text-black'
+                            : 'text-white hover:bg-[#d6eaf8] hover:text-black',
+                          'rounded-md px-3 py-2 text-sm font-medium',
+                        )}
+                      >
+                        {item.name}
+                      </Link>
+                    ))}
+                  </div>
+                </div>
+              </div>
+              <div className="flex flex-1 justify-center px-2 lg:ml-6 lg:justify-end">
+                <div className="grid w-full max-w-lg grid-cols-1 lg:max-w-xs">
+                  <input
+                    name="search"
+                    placeholder="Search"
+                    aria-label="Search"
+                    className="col-start-1 row-start-1 block w-full rounded-md bg-[#d6eaf8] py-1.5 pr-3 pl-10 text-base text-black placeholder:text-black/60 focus:outline-2 focus:-outline-offset-2 focus:outline-white sm:text-sm/6"
+                  />
+                  <MagnifyingGlassIcon
+                    aria-hidden="true"
+                    className="pointer-events-none col-start-1 row-start-1 ml-3 size-5 self-center text-black/60"
+                  />
+                </div>
+              </div>
+              <div className="flex lg:hidden">
+                {/* Mobile menu button */}
+                <DisclosureButton className="group relative inline-flex items-center justify-center rounded-md bg-[#288dcf] p-2 text-[#d6eaf8] hover:bg-[#288dcf]/90 hover:text-white focus:outline-2 focus:outline-offset-2 focus:outline-white">
+                  <span className="absolute -inset-0.5" />
+                  <span className="sr-only">Open main menu</span>
+                  <Bars3Icon aria-hidden="true" className="block size-6 group-data-open:hidden" />
+                  <XMarkIcon aria-hidden="true" className="hidden size-6 group-data-open:block" />
+                </DisclosureButton>
+              </div>
+              <div className="hidden lg:ml-4 lg:block">
+                <div className="flex items-center">
+                  <button
+                    type="button"
+                    className="relative shrink-0 rounded-full p-1 text-[#d6eaf8] hover:text-white focus:outline-2 focus:outline-offset-2 focus:outline-white"
+                  >
+                    <span className="absolute -inset-1.5" />
+                    <span className="sr-only">View notifications</span>
+                    <BellIcon aria-hidden="true" className="size-6" />
+                  </button>
+
+                  {/* Profile dropdown */}
+                  <Menu as="div" className="relative ml-3 shrink-0">
+                    <MenuButton className="relative flex rounded-full focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white">
+                      <span className="absolute -inset-1.5" />
+                      <span className="sr-only">Open user menu</span>
+                      <img
+                        alt=""
+                        src={user.imageUrl}
+                        className="size-8 rounded-full outline -outline-offset-1 outline-white/10"
+                      />
+                    </MenuButton>
+
+                    <MenuItems
+                      transition
+                      className="absolute right-0 z-10 mt-2 w-48 origin-top-right rounded-md bg-white py-1 shadow-lg outline-1 outline-black/5 transition data-closed:scale-95 data-closed:transform data-closed:opacity-0 data-enter:duration-100 data-enter:ease-out data-leave:duration-75 data-leave:ease-in"
+                    >
+                      {userNavigation.map((item) => (
+                        <MenuItem key={item.name}>
+                          <Link
+                            to={item.href}
+                            className="block px-4 py-2 text-sm text-gray-700 data-focus:bg-[#d6eaf8] data-focus:text-black data-focus:outline-hidden"
+                          >
+                            {item.name}
+                          </Link>
+                        </MenuItem>
+                      ))}
+                    </MenuItems>
+                  </Menu>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <DisclosurePanel className="lg:hidden">
+            <div className="space-y-1 px-2 pt-2 pb-3">
+              {navigation.map((item) => (
+                <DisclosureButton
+                  key={item.name}
+                  as={Link}
+                  to={item.href}
+                  aria-current={item.current ? 'page' : undefined}
+                  className={classNames(
+                    item.current
+                      ? 'bg-[#d6eaf8] text-black'
+                      : 'text-white hover:bg-[#d6eaf8] hover:text-black',
+                    'block rounded-md px-3 py-2 text-base font-medium',
+                  )}
+                >
+                  {item.name}
+                </DisclosureButton>
+              ))}
+            </div>
+            <div className="border-t border-[#d6eaf8] pt-4 pb-3">
+              <div className="flex items-center px-5">
+                <div className="shrink-0">
+                  <img
+                    alt=""
+                    src={user.imageUrl}
+                    className="size-10 rounded-full outline -outline-offset-1 outline-white/10"
+                  />
+                </div>
+                <div className="ml-3">
+                  <div className="text-base font-medium text-white">{user.name}</div>
+                  <div className="text-sm font-medium text-[#d6eaf8]">{user.email}</div>
+                </div>
+                <button
+                  type="button"
+                  className="relative ml-auto shrink-0 rounded-full p-1 text-[#d6eaf8] hover:text-white focus:outline-2 focus:outline-offset-2 focus:outline-white"
+                >
+                  <span className="absolute -inset-1.5" />
+                  <span className="sr-only">View notifications</span>
+                  <BellIcon aria-hidden="true" className="size-6" />
+                </button>
+              </div>
+              <div className="mt-3 space-y-1 px-2">
+                {userNavigation.map((item) => (
+                  <DisclosureButton
+                    key={item.name}
+                    as={Link}
+                    to={item.href}
+                    className="block rounded-md px-3 py-2 text-base font-medium text-white hover:bg-[#d6eaf8] hover:text-black"
+                  >
+                    {item.name}
+                  </DisclosureButton>
+                ))}
+              </div>
+            </div>
+          </DisclosurePanel>
+        </Disclosure>
+        <header className="py-10">
+          <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+            <h1 className="text-3xl font-bold tracking-tight text-white">Dashboard</h1>
+          </div>
+        </header>
+      </div>
+
+      <main className="-mt-32">
+        <div className="mx-auto max-w-7xl px-4 pb-12 sm:px-6 lg:px-8">
+          <div className="rounded-lg bg-white px-5 py-6 shadow-sm sm:px-6">{children}</div>
+        </div>
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add operations layout using headless UI components
- apply brand colors (#288dcf and #d6eaf8) to navigation, search, and mobile menu

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab6a32b1d8832e91d4c566dba96186