### PR TITLE
Add ops home page and dashboard toggle for operations mode

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,6 +17,7 @@ import About from './pages/About';
 import Press from './pages/Press';
 import Support from './pages/Support';
 import Contact from './pages/Contact';
+import OpsHome from './pages/OpsHome';
 import ProtectedRoute from './components/ProtectedRoute';
 import Pricing from './pages/Pricing';
 
@@ -43,6 +44,7 @@ function App() {
         <Route path="/terms" element={<TermsOfService />} />
         <Route path="/privacy" element={<PrivacyPolicy />} />
         <Route path="/pricing" element={<Pricing />} />
+        <Route path="/ops" element={<ProtectedRoute><OpsHome /></ProtectedRoute>} />
       </Routes>
     </>
   );

--- a/src/components/OpsToggle.jsx
+++ b/src/components/OpsToggle.jsx
@@ -1,0 +1,26 @@
+import { useNavigate } from 'react-router-dom';
+import { withBase } from '../utils/basePath.js';
+
+export default function OpsToggle() {
+  const navigate = useNavigate();
+
+  const handleChange = (e) => {
+    if (e.target.checked) {
+      navigate(withBase('/ops'));
+    }
+  };
+
+  return (
+    <div className="group relative inline-flex w-11 shrink-0 rounded-full bg-gray-200 p-0.5 inset-ring inset-ring-gray-900/5 outline-offset-2 outline-[#288dcf] transition-colors duration-200 ease-in-out has-checked:bg-[#288dcf] has-focus-visible:outline-2">
+      <span className="size-5 rounded-full bg-white shadow-xs ring-1 ring-gray-900/5 transition-transform duration-200 ease-in-out group-has-checked:translate-x-5" />
+      <input
+        name="ops-mode"
+        type="checkbox"
+        aria-label="Enable ops mode"
+        className="absolute inset-0 appearance-none focus:outline-hidden"
+        onChange={handleChange}
+      />
+    </div>
+  );
+}
+

--- a/src/layout/InternalLayout.jsx
+++ b/src/layout/InternalLayout.jsx
@@ -19,6 +19,7 @@ import {
   ArrowLeftOnRectangleIcon,
 } from '@heroicons/react/24/outline';
 import { UserButton, SignOutButton } from '@clerk/clerk-react';
+import OpsToggle from '../components/OpsToggle.jsx';
 import { withBase } from '../utils/basePath.js';
 
 const navigation = [
@@ -196,7 +197,12 @@ export default function InternalLayout({ children }) {
             <div className="flex flex-1 justify-end gap-x-4 self-stretch lg:gap-x-6">
               <div className="flex items-center gap-x-4 lg:gap-x-6">
                 {/* notifications placeholder */}
-                <div aria-hidden="true" className="hidden lg:block lg:h-6 lg:w-px lg:bg-gray-200" />
+                {pathname === '/dashboard' && (
+                  <>
+                    <OpsToggle />
+                    <div aria-hidden="true" className="hidden lg:block lg:h-6 lg:w-px lg:bg-gray-200" />
+                  </>
+                )}
                 <UserButton
                   afterSignOutUrl={withBase('/')}
                   userProfileMode="navigation"

--- a/src/layout/OpsLayout.jsx
+++ b/src/layout/OpsLayout.jsx
@@ -1,35 +1,18 @@
 'use client';
 
 import { Link } from 'react-router-dom';
-import {
-  Disclosure,
-  DisclosureButton,
-  DisclosurePanel,
-  Menu,
-  MenuButton,
-  MenuItem,
-  MenuItems,
-} from '@headlessui/react';
+import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/react';
+import { UserButton } from '@clerk/clerk-react';
+import { withBase } from '../utils/basePath.js';
 import { MagnifyingGlassIcon } from '@heroicons/react/20/solid';
 import { Bars3Icon, BellIcon, XMarkIcon } from '@heroicons/react/24/outline';
 
-const user = {
-  name: 'Tom Cook',
-  email: 'tom@example.com',
-  imageUrl:
-    'https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
-};
 const navigation = [
   { name: 'Dashboard', href: '#', current: true },
   { name: 'Team', href: '#', current: false },
   { name: 'Projects', href: '#', current: false },
   { name: 'Calendar', href: '#', current: false },
   { name: 'Reports', href: '#', current: false },
-];
-const userNavigation = [
-  { name: 'Your profile', href: '#' },
-  { name: 'Settings', href: '#' },
-  { name: 'Sign out', href: '#' },
 ];
 
 function classNames(...classes) {
@@ -105,34 +88,11 @@ export default function OpsLayout({ children }) {
                     <BellIcon aria-hidden="true" className="size-6" />
                   </button>
 
-                  {/* Profile dropdown */}
-                  <Menu as="div" className="relative ml-3 shrink-0">
-                    <MenuButton className="relative flex rounded-full focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white">
-                      <span className="absolute -inset-1.5" />
-                      <span className="sr-only">Open user menu</span>
-                      <img
-                        alt=""
-                        src={user.imageUrl}
-                        className="size-8 rounded-full outline -outline-offset-1 outline-white/10"
-                      />
-                    </MenuButton>
-
-                    <MenuItems
-                      transition
-                      className="absolute right-0 z-10 mt-2 w-48 origin-top-right rounded-md bg-white py-1 shadow-lg outline-1 outline-black/5 transition data-closed:scale-95 data-closed:transform data-closed:opacity-0 data-enter:duration-100 data-enter:ease-out data-leave:duration-75 data-leave:ease-in"
-                    >
-                      {userNavigation.map((item) => (
-                        <MenuItem key={item.name}>
-                          <Link
-                            to={item.href}
-                            className="block px-4 py-2 text-sm text-gray-700 data-focus:bg-[#d6eaf8] data-focus:text-black data-focus:outline-hidden"
-                          >
-                            {item.name}
-                          </Link>
-                        </MenuItem>
-                      ))}
-                    </MenuItems>
-                  </Menu>
+                  <UserButton
+                    afterSignOutUrl={withBase('/')}
+                    userProfileMode="navigation"
+                    userProfileUrl={withBase('/account')}
+                  />
                 </div>
               </div>
             </div>
@@ -157,46 +117,20 @@ export default function OpsLayout({ children }) {
                 </DisclosureButton>
               ))}
             </div>
-            <div className="border-t border-[#d6eaf8] pt-4 pb-3">
-              <div className="flex items-center px-5">
-                <div className="shrink-0">
-                  <img
-                    alt=""
-                    src={user.imageUrl}
-                    className="size-10 rounded-full outline -outline-offset-1 outline-white/10"
-                  />
-                </div>
-                <div className="ml-3">
-                  <div className="text-base font-medium text-white">{user.name}</div>
-                  <div className="text-sm font-medium text-[#d6eaf8]">{user.email}</div>
-                </div>
-                <button
-                  type="button"
-                  className="relative ml-auto shrink-0 rounded-full p-1 text-[#d6eaf8] hover:text-white focus:outline-2 focus:outline-offset-2 focus:outline-white"
-                >
-                  <span className="absolute -inset-1.5" />
-                  <span className="sr-only">View notifications</span>
-                  <BellIcon aria-hidden="true" className="size-6" />
-                </button>
-              </div>
-              <div className="mt-3 space-y-1 px-2">
-                {userNavigation.map((item) => (
-                  <DisclosureButton
-                    key={item.name}
-                    as={Link}
-                    to={item.href}
-                    className="block rounded-md px-3 py-2 text-base font-medium text-white hover:bg-[#d6eaf8] hover:text-black"
-                  >
-                    {item.name}
-                  </DisclosureButton>
-                ))}
+            <div className="border-t border-[#d6eaf8] py-4">
+              <div className="px-5">
+                <UserButton
+                  afterSignOutUrl={withBase('/')}
+                  userProfileMode="navigation"
+                  userProfileUrl={withBase('/account')}
+                />
               </div>
             </div>
           </DisclosurePanel>
         </Disclosure>
         <header className="py-10">
           <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-            <h1 className="text-3xl font-bold tracking-tight text-white">Dashboard</h1>
+            <h1 className="text-3xl font-bold tracking-tight text-white">Ops Home</h1>
           </div>
         </header>
       </div>

--- a/src/pages/OpsHome.jsx
+++ b/src/pages/OpsHome.jsx
@@ -1,0 +1,13 @@
+import OpsLayout from '../layout/OpsLayout';
+
+export default function OpsHome() {
+  return (
+    <OpsLayout>
+      <div className="space-y-6">
+        <h2 className="text-2xl font-semibold text-gray-900">Welcome to Ops Home</h2>
+        <p className="text-gray-600">This area is reserved for operational tools.</p>
+      </div>
+    </OpsLayout>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add Ops toggle and route to Ops Home
- integrate Clerk UserButton into OpsLayout
- display operations toggle on dashboard for quick access

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab6d79c900832eb6039b8ba8afda22