### PR TITLE
Revamp Ops Home and toggle navigation

### DIFF
--- a/src/components/OpsToggle.jsx
+++ b/src/components/OpsToggle.jsx
@@ -1,12 +1,14 @@
 import { useNavigate } from 'react-router-dom';
 import { withBase } from '../utils/basePath.js';
 
-export default function OpsToggle() {
+export default function OpsToggle({ defaultChecked = false }) {
   const navigate = useNavigate();
 
   const handleChange = (e) => {
     if (e.target.checked) {
       navigate(withBase('/ops'));
+    } else {
+      navigate(withBase('/dashboard'));
     }
   };
 
@@ -18,6 +20,7 @@ export default function OpsToggle() {
         type="checkbox"
         aria-label="Enable ops mode"
         className="absolute inset-0 appearance-none focus:outline-hidden"
+        defaultChecked={defaultChecked}
         onChange={handleChange}
       />
     </div>

--- a/src/layout/OpsLayout.jsx
+++ b/src/layout/OpsLayout.jsx
@@ -4,8 +4,8 @@ import { Link } from 'react-router-dom';
 import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/react';
 import { UserButton } from '@clerk/clerk-react';
 import { withBase } from '../utils/basePath.js';
-import { MagnifyingGlassIcon } from '@heroicons/react/20/solid';
-import { Bars3Icon, BellIcon, XMarkIcon } from '@heroicons/react/24/outline';
+import OpsToggle from '../components/OpsToggle.jsx';
+import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/outline';
 
 const navigation = [
   { name: 'Dashboard', href: '#', current: true },
@@ -22,16 +22,16 @@ function classNames(...classes) {
 export default function OpsLayout({ children }) {
   return (
     <div className="min-h-full">
-      <div className="bg-[#288dcf] pb-32">
+      <div className="bg-[#288dcf] pb-6">
         <Disclosure as="nav" className="border-b border-[#d6eaf8]/25 bg-[#288dcf] lg:border-none">
           <div className="mx-auto max-w-7xl px-2 sm:px-4 lg:px-8">
             <div className="relative flex h-16 items-center justify-between lg:border-b lg:border-[#d6eaf8]/25">
               <div className="flex items-center px-2 lg:px-0">
                 <div className="shrink-0">
                   <img
-                    alt="Your Company"
-                    src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=blue&shade=300"
-                    className="block size-8"
+                    alt="BoardBid Logo"
+                    src="https://ik.imagekit.io/boardbid/BoardBid%20final.avif?updatedAt=1755054268128"
+                    className="h-8 w-auto"
                   />
                 </div>
                 <div className="hidden lg:ml-10 lg:block">
@@ -54,20 +54,6 @@ export default function OpsLayout({ children }) {
                   </div>
                 </div>
               </div>
-              <div className="flex flex-1 justify-center px-2 lg:ml-6 lg:justify-end">
-                <div className="grid w-full max-w-lg grid-cols-1 lg:max-w-xs">
-                  <input
-                    name="search"
-                    placeholder="Search"
-                    aria-label="Search"
-                    className="col-start-1 row-start-1 block w-full rounded-md bg-[#d6eaf8] py-1.5 pr-3 pl-10 text-base text-black placeholder:text-black/60 focus:outline-2 focus:-outline-offset-2 focus:outline-white sm:text-sm/6"
-                  />
-                  <MagnifyingGlassIcon
-                    aria-hidden="true"
-                    className="pointer-events-none col-start-1 row-start-1 ml-3 size-5 self-center text-black/60"
-                  />
-                </div>
-              </div>
               <div className="flex lg:hidden">
                 {/* Mobile menu button */}
                 <DisclosureButton className="group relative inline-flex items-center justify-center rounded-md bg-[#288dcf] p-2 text-[#d6eaf8] hover:bg-[#288dcf]/90 hover:text-white focus:outline-2 focus:outline-offset-2 focus:outline-white">
@@ -77,23 +63,13 @@ export default function OpsLayout({ children }) {
                   <XMarkIcon aria-hidden="true" className="hidden size-6 group-data-open:block" />
                 </DisclosureButton>
               </div>
-              <div className="hidden lg:ml-4 lg:block">
-                <div className="flex items-center">
-                  <button
-                    type="button"
-                    className="relative shrink-0 rounded-full p-1 text-[#d6eaf8] hover:text-white focus:outline-2 focus:outline-offset-2 focus:outline-white"
-                  >
-                    <span className="absolute -inset-1.5" />
-                    <span className="sr-only">View notifications</span>
-                    <BellIcon aria-hidden="true" className="size-6" />
-                  </button>
-
-                  <UserButton
-                    afterSignOutUrl={withBase('/')}
-                    userProfileMode="navigation"
-                    userProfileUrl={withBase('/account')}
-                  />
-                </div>
+              <div className="hidden lg:ml-4 lg:flex lg:items-center lg:space-x-4">
+                <OpsToggle defaultChecked />
+                <UserButton
+                  afterSignOutUrl={withBase('/')}
+                  userProfileMode="navigation"
+                  userProfileUrl={withBase('/account')}
+                />
               </div>
             </div>
           </div>
@@ -118,7 +94,8 @@ export default function OpsLayout({ children }) {
               ))}
             </div>
             <div className="border-t border-[#d6eaf8] py-4">
-              <div className="px-5">
+              <div className="flex items-center justify-between px-5">
+                <OpsToggle defaultChecked />
                 <UserButton
                   afterSignOutUrl={withBase('/')}
                   userProfileMode="navigation"
@@ -135,11 +112,7 @@ export default function OpsLayout({ children }) {
         </header>
       </div>
 
-      <main className="-mt-32">
-        <div className="mx-auto max-w-7xl px-4 pb-12 sm:px-6 lg:px-8">
-          <div className="rounded-lg bg-white px-5 py-6 shadow-sm sm:px-6">{children}</div>
-        </div>
-      </main>
+      <main className="py-6">{children}</main>
     </div>
   );
 }

--- a/src/pages/OpsHome.jsx
+++ b/src/pages/OpsHome.jsx
@@ -3,9 +3,11 @@ import OpsLayout from '../layout/OpsLayout';
 export default function OpsHome() {
   return (
     <OpsLayout>
-      <div className="space-y-6">
-        <h2 className="text-2xl font-semibold text-gray-900">Welcome to Ops Home</h2>
-        <p className="text-gray-600">This area is reserved for operational tools.</p>
+      <div className="container mx-auto sm:px-6 lg:px-8">
+        <div className="space-y-6">
+          <h2 className="text-2xl font-semibold text-gray-900">Welcome to Ops Home</h2>
+          <p className="text-gray-600">This area is reserved for operational tools.</p>
+        </div>
       </div>
     </OpsLayout>
   );


### PR DESCRIPTION
## Summary
- Replace Ops header logo and drop search/notifications
- Add Ops mode toggle that returns to dashboard when disabled
- Expand Ops Home body container for future content

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab706e4ea4832e97d44d29c491ed14