### PR TITLE
feat: update ops layout styling

### DIFF
--- a/src/layout/OpsLayout.jsx
+++ b/src/layout/OpsLayout.jsx
@@ -22,15 +22,15 @@ function classNames(...classes) {
 export default function OpsLayout({ children }) {
   return (
     <div className="min-h-full">
-      <div className="bg-[#4ba6dc] pb-6">
-        <Disclosure as="nav" className="border-b border-[#d6eaf8]/25 bg-[#4ba6dc] lg:border-none">
+      <div className="bg-black pb-6">
+        <Disclosure as="nav" className="border-b border-white/10 bg-black lg:border-none">
           <div className="mx-auto max-w-7xl px-2 sm:px-4 lg:px-8">
-            <div className="relative flex h-16 items-center justify-between lg:border-b lg:border-[#d6eaf8]/25">
+            <div className="relative flex h-16 items-center justify-between lg:border-b lg:border-white/10">
               <div className="flex items-center px-2 lg:px-0">
                 <div className="shrink-0">
                   <img
                     alt="BoardBid Logo"
-                    src="https://ik.imagekit.io/boardbid/BoardBid%20final.avif?updatedAt=1755054268128"
+                    src="https://ik.imagekit.io/boardbid/BoardBid%20logo-White.avif"
                     className="h-8 w-auto"
                   />
                 </div>
@@ -43,8 +43,8 @@ export default function OpsLayout({ children }) {
                         aria-current={item.current ? 'page' : undefined}
                         className={classNames(
                           item.current
-                            ? 'bg-[#d6eaf8] text-black'
-                            : 'text-white hover:bg-[#d6eaf8] hover:text-black',
+                            ? 'bg-white text-black'
+                            : 'text-white hover:bg-white hover:text-black',
                           'rounded-md px-3 py-2 text-sm font-medium',
                         )}
                       >
@@ -56,7 +56,7 @@ export default function OpsLayout({ children }) {
               </div>
               <div className="flex lg:hidden">
                 {/* Mobile menu button */}
-                <DisclosureButton className="group relative inline-flex items-center justify-center rounded-md bg-[#288dcf] p-2 text-[#d6eaf8] hover:bg-[#288dcf]/90 hover:text-white focus:outline-2 focus:outline-offset-2 focus:outline-white">
+                <DisclosureButton className="group relative inline-flex items-center justify-center rounded-md bg-gray-800 p-2 text-gray-400 hover:bg-gray-700 hover:text-white focus:outline-2 focus:outline-offset-2 focus:outline-white">
                   <span className="absolute -inset-0.5" />
                   <span className="sr-only">Open main menu</span>
                   <Bars3Icon aria-hidden="true" className="block size-6 group-data-open:hidden" />
@@ -65,6 +65,7 @@ export default function OpsLayout({ children }) {
               </div>
               <div className="hidden lg:ml-4 lg:flex lg:items-center lg:space-x-4">
                 <OpsToggle defaultChecked />
+                <div aria-hidden="true" className="hidden lg:block lg:h-6 lg:w-px lg:bg-white/20" />
                 <UserButton
                   afterSignOutUrl={withBase('/')}
                   userProfileMode="navigation"
@@ -84,8 +85,8 @@ export default function OpsLayout({ children }) {
                   aria-current={item.current ? 'page' : undefined}
                   className={classNames(
                     item.current
-                      ? 'bg-[#d6eaf8] text-black'
-                      : 'text-white hover:bg-[#d6eaf8] hover:text-black',
+                      ? 'bg-white text-black'
+                      : 'text-white hover:bg-white hover:text-black',
                     'block rounded-md px-3 py-2 text-base font-medium',
                   )}
                 >
@@ -93,7 +94,7 @@ export default function OpsLayout({ children }) {
                 </DisclosureButton>
               ))}
             </div>
-            <div className="border-t border-[#d6eaf8] py-4">
+            <div className="border-t border-white/10 py-4">
               <div className="flex items-center justify-between px-5">
                 <OpsToggle defaultChecked />
                 <UserButton


### PR DESCRIPTION
## Summary
- restyle Ops layout top bar with a black background and white logo
- add divider between Ops toggle and user button, mirroring dashboard
- adjust menu and navigation colors for dark theme

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ab782d7cb0832eb31f70bce3d01648