### PR TITLE
feat: add campaign summary stats component

### DIFF
--- a/src/components/CampaignStats.jsx
+++ b/src/components/CampaignStats.jsx
@@ -1,0 +1,31 @@
+export default function CampaignStats({ campaigns = [] }) {
+  const countByStatus = (status) =>
+    campaigns.filter((c) => {
+      const val = (c.status || c.campaign_status || '').toLowerCase();
+      return val === status;
+    }).length;
+
+  const stats = [
+    { name: 'Total Campaigns', stat: campaigns.length },
+    { name: 'Unassigned', stat: countByStatus('unassigned') },
+    { name: 'In Progress', stat: countByStatus('in progress') },
+    { name: 'Closed', stat: countByStatus('closed') },
+  ];
+
+  return (
+    <div className="mt-8">
+      <h3 className="text-base font-semibold text-gray-900 dark:text-white">Campaign Summary</h3>
+      <dl className="mt-5 grid grid-cols-1 gap-5 sm:grid-cols-4">
+        {stats.map((item) => (
+          <div
+            key={item.name}
+            className="overflow-hidden rounded-lg bg-white px-4 py-5 shadow-sm ring-1 ring-gray-200 sm:p-6 dark:bg-gray-900 dark:ring-white/10"
+          >
+            <dt className="truncate text-sm font-medium text-gray-500 dark:text-gray-400">{item.name}</dt>
+            <dd className="mt-1 text-3xl font-semibold tracking-tight text-gray-900 dark:text-white">{item.stat}</dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  );
+}

--- a/src/pages/Campaigns.jsx
+++ b/src/pages/Campaigns.jsx
@@ -6,6 +6,7 @@ import { useUser } from '@clerk/clerk-react';
 import Lottie from 'lottie-react';
 import loadingAnim from '../assets/loading.json';
 import { MegaphoneIcon } from '@heroicons/react/24/outline';
+import CampaignStats from '../components/CampaignStats';
 
 const API_URL = import.meta.env.VITE_API_URL;
 
@@ -150,6 +151,7 @@ export default function Campaigns() {
   return (
     <InternalLayout>
       <PageHeader title="My Campaigns" />
+      {!isLoading && <CampaignStats campaigns={campaigns} />}
 
       {isLoading ? (
         <div className="flex h-48 items-center justify-center">


### PR DESCRIPTION
## Summary
- add `CampaignStats` component showing totals and status counts
- display campaign stats above the campaign list

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ab830f0c80832e89b26c95dcca9034