### PR TITLE
feat: expand ops pages and campaigns table

### DIFF
--- a/src/components/CampaignsOpsStats.jsx
+++ b/src/components/CampaignsOpsStats.jsx
@@ -1,6 +1,6 @@
-export default function CampaignsOpsStats() {
+export default function CampaignsOpsStats({ campaigns = [] }) {
   const stats = [
-    { name: 'Total Subscribers', stat: '71,897' },
+    { name: 'Total Campaigns', stat: campaigns.length.toString() },
     { name: 'Avg. Open Rate', stat: '58.16%' },
     { name: 'Avg. Click Rate', stat: '24.57%' },
   ];

--- a/src/layout/OpsLayout.jsx
+++ b/src/layout/OpsLayout.jsx
@@ -24,7 +24,7 @@ export default function OpsLayout({ children }) {
     <div className="min-h-full">
       <div className="bg-black pb-6">
         <Disclosure as="nav" className="border-b border-white/10 bg-black lg:border-none">
-          <div className="mx-auto max-w-7xl px-2 sm:px-4 lg:px-8">
+          <div className="px-2 sm:px-4 lg:px-8">
             <div className="relative flex h-16 items-center justify-between lg:border-b lg:border-white/10">
               <div className="flex items-center px-2 lg:px-0">
                 <div className="shrink-0">
@@ -107,13 +107,15 @@ export default function OpsLayout({ children }) {
           </DisclosurePanel>
         </Disclosure>
         <header className="py-10">
-          <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+          <div className="px-4 sm:px-6 lg:px-8">
             <h1 className="text-3xl font-bold tracking-tight text-white">Ops Home</h1>
           </div>
         </header>
       </div>
 
-      <main className="py-6">{children}</main>
+      <main className="py-6">
+        <div className="px-4 sm:px-6 lg:px-8">{children}</div>
+      </main>
     </div>
   );
 }

--- a/src/pages/OpsHome.jsx
+++ b/src/pages/OpsHome.jsx
@@ -1,5 +1,4 @@
 import OpsLayout from '../layout/OpsLayout';
-import Card from '../components/Card';
 import CampaignsOpsStats from '../components/CampaignsOpsStats';
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
@@ -32,72 +31,76 @@ export default function OpsHome() {
 
   return (
     <OpsLayout>
-      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-        <CampaignsOpsStats />
-        <Card title="Campaigns">
-          {isLoading ? (
-            <div className="py-8 text-center text-sm text-gray-500">Loading...</div>
-          ) : campaigns.length === 0 ? (
-            <div className="py-8 text-center text-sm text-gray-500">No campaigns found.</div>
-          ) : (
-            <div className="flow-root overflow-x-auto">
-              <table className="min-w-full text-left">
-                <thead className="bg-white">
-                  <tr>
-                    <th scope="col" className="px-3 py-3.5 text-sm font-semibold text-gray-900">
-                      Company
-                    </th>
-                    <th
-                      scope="col"
-                      className="hidden px-3 py-3.5 text-sm font-semibold text-gray-900 sm:table-cell"
-                    >
-                      Type
-                    </th>
-                    <th
-                      scope="col"
-                      className="hidden px-3 py-3.5 text-sm font-semibold text-gray-900 md:table-cell"
-                    >
-                      Budget
-                    </th>
-                    <th scope="col" className="px-3 py-3.5 text-sm font-semibold text-gray-900">
-                      Status
-                    </th>
-                    <th scope="col" className="py-3.5 pl-3 pr-4 sm:pr-6">
-                      <span className="sr-only">View</span>
-                    </th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-gray-200">
-                  {campaigns.map((c) => (
-                    <tr key={c.id}>
-                      <td className="whitespace-nowrap px-3 py-4 text-sm font-medium text-gray-900">
-                        {c.company_name || '-'}
-                      </td>
-                      <td className="hidden whitespace-nowrap px-3 py-4 text-sm text-gray-500 sm:table-cell">
-                        {fmt(c.campaign_type)}
-                      </td>
-                      <td className="hidden whitespace-nowrap px-3 py-4 text-sm text-gray-500 md:table-cell">
-                        {c.ooh_budget_range || '-'}
-                      </td>
-                      <td className="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
-                        {c.status || '-'}
-                      </td>
-                      <td className="whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
-                        <Link
-                          to={`/campaigns/${c.id}`}
-                          className="text-indigo-600 hover:text-indigo-900"
-                        >
-                          View<span className="sr-only">, {c.company_name}</span>
-                        </Link>
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
+      <CampaignsOpsStats campaigns={campaigns} />
+      {isLoading ? (
+        <div className="py-8 text-center text-sm text-gray-500">Loading...</div>
+      ) : campaigns.length === 0 ? (
+        <div className="py-8 text-center text-sm text-gray-500">No campaigns found.</div>
+      ) : (
+        <>
+          <div className="mt-8 sm:flex sm:items-center">
+            <div className="sm:flex-auto">
+              <h1 className="text-base font-semibold text-gray-900">Campaigns</h1>
+              <p className="mt-2 text-sm text-gray-700">A list of all campaigns.</p>
             </div>
-          )}
-        </Card>
-      </div>
+          </div>
+          <div className="mt-8 flow-root overflow-x-auto">
+            <table className="w-full text-left">
+              <thead className="bg-white">
+                <tr>
+                  <th scope="col" className="px-3 py-3.5 text-sm font-semibold text-gray-900">
+                    Company
+                  </th>
+                  <th
+                    scope="col"
+                    className="hidden px-3 py-3.5 text-sm font-semibold text-gray-900 sm:table-cell"
+                  >
+                    Type
+                  </th>
+                  <th
+                    scope="col"
+                    className="hidden px-3 py-3.5 text-sm font-semibold text-gray-900 md:table-cell"
+                  >
+                    Budget
+                  </th>
+                  <th scope="col" className="px-3 py-3.5 text-sm font-semibold text-gray-900">
+                    Status
+                  </th>
+                  <th scope="col" className="py-3.5 pl-3 pr-4 sm:pr-6">
+                    <span className="sr-only">View</span>
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-200">
+                {campaigns.map((c) => (
+                  <tr key={c.id}>
+                    <td className="whitespace-nowrap px-3 py-4 text-sm font-medium text-gray-900">
+                      {c.company_name || '-'}
+                    </td>
+                    <td className="hidden whitespace-nowrap px-3 py-4 text-sm text-gray-500 sm:table-cell">
+                      {fmt(c.campaign_type)}
+                    </td>
+                    <td className="hidden whitespace-nowrap px-3 py-4 text-sm text-gray-500 md:table-cell">
+                      {c.ooh_budget_range || '-'}
+                    </td>
+                    <td className="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
+                      {c.status || '-'}
+                    </td>
+                    <td className="whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
+                      <Link
+                        to={`/campaigns/${c.id}`}
+                        className="text-indigo-600 hover:text-indigo-900"
+                      >
+                        View<span className="sr-only">, {c.company_name}</span>
+                      </Link>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </>
+      )}
     </OpsLayout>
   );
 }


### PR DESCRIPTION
## Summary
- widen ops layout to use full screen width
- derive campaign stats total from fetched campaigns
- display campaign list in simple table without cards

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab8a0c418c832e940512fbdc2125cd