### PR TITLE
feat: ops campaign assignment and inbox

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -18,6 +18,7 @@ import Press from './pages/Press';
 import Support from './pages/Support';
 import Contact from './pages/Contact';
 import OpsHome from './pages/OpsHome';
+import OpsInbox from './pages/OpsInbox.jsx';
 import ProtectedRoute from './components/ProtectedRoute';
 import Pricing from './pages/Pricing';
 
@@ -45,6 +46,7 @@ function App() {
         <Route path="/privacy" element={<PrivacyPolicy />} />
         <Route path="/pricing" element={<Pricing />} />
         <Route path="/ops" element={<ProtectedRoute><OpsHome /></ProtectedRoute>} />
+        <Route path="/ops/inbox" element={<ProtectedRoute><OpsInbox /></ProtectedRoute>} />
       </Routes>
     </>
   );

--- a/src/components/OpsAssignMenu.jsx
+++ b/src/components/OpsAssignMenu.jsx
@@ -1,0 +1,50 @@
+import { Menu, MenuButton, MenuItem, MenuItems } from '@headlessui/react';
+import { ChevronDownIcon } from '@heroicons/react/20/solid';
+
+export default function OpsAssignMenu({ current, opsUsers = [], onSelect }) {
+  return (
+    <Menu as="div" className="relative inline-block text-left">
+      <MenuButton className="inline-flex w-full justify-center gap-x-1.5 rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50">
+        {current ? (
+          <span className="flex items-center">
+            {current.image_url ? (
+              <img
+                src={current.image_url}
+                alt={current.email}
+                className="mr-2 h-5 w-5 rounded-full"
+              />
+            ) : null}
+            {current.email || 'Assign'}
+          </span>
+        ) : (
+          'Assign'
+        )}
+        <ChevronDownIcon aria-hidden="true" className="-mr-1 h-5 w-5 text-gray-400" />
+      </MenuButton>
+      <MenuItems className="absolute right-0 z-10 mt-2 w-56 origin-top-right divide-y divide-gray-100 rounded-md bg-white shadow-lg outline-1 outline-black/5">
+        <div className="max-h-60 overflow-y-auto py-1">
+          {opsUsers.map((u) => (
+            <MenuItem key={u.id}>
+              {({ active }) => (
+                <button
+                  type="button"
+                  onClick={() => onSelect(u)}
+                  className={`${active ? 'bg-gray-100 text-gray-900' : 'text-gray-700'} group flex w-full items-center px-4 py-2 text-sm`}
+                >
+                  {u.image_url ? (
+                    <img
+                      src={u.image_url}
+                      alt={u.email}
+                      className="mr-3 h-5 w-5 rounded-full"
+                    />
+                  ) : null}
+                  {u.email}
+                </button>
+              )}
+            </MenuItem>
+          ))}
+        </div>
+      </MenuItems>
+    </Menu>
+  );
+}

--- a/src/layout/OpsLayout.jsx
+++ b/src/layout/OpsLayout.jsx
@@ -1,25 +1,23 @@
 'use client';
 
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/react';
 import { UserButton } from '@clerk/clerk-react';
 import { withBase } from '../utils/basePath.js';
 import OpsToggle from '../components/OpsToggle.jsx';
 import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/outline';
 
-const navigation = [
-  { name: 'Dashboard', href: '#', current: true },
-  { name: 'Team', href: '#', current: false },
-  { name: 'Projects', href: '#', current: false },
-  { name: 'Calendar', href: '#', current: false },
-  { name: 'Reports', href: '#', current: false },
-];
-
 function classNames(...classes) {
   return classes.filter(Boolean).join(' ');
 }
 
-export default function OpsLayout({ children }) {
+export default function OpsLayout({ children, title = 'Ops Home' }) {
+  const location = useLocation();
+  const navigation = [
+    { name: 'Campaigns', href: withBase('/ops') },
+    { name: 'Inbox', href: withBase('/ops/inbox') },
+  ];
+
   return (
     <div className="min-h-full">
       <div className="bg-black pb-6">
@@ -40,9 +38,8 @@ export default function OpsLayout({ children }) {
                       <Link
                         key={item.name}
                         to={item.href}
-                        aria-current={item.current ? 'page' : undefined}
                         className={classNames(
-                          item.current
+                          location.pathname === item.href
                             ? 'bg-white text-black'
                             : 'text-white hover:bg-white hover:text-black',
                           'rounded-md px-3 py-2 text-sm font-medium',
@@ -55,7 +52,6 @@ export default function OpsLayout({ children }) {
                 </div>
               </div>
               <div className="flex lg:hidden">
-                {/* Mobile menu button */}
                 <DisclosureButton className="group relative inline-flex items-center justify-center rounded-md bg-gray-800 p-2 text-gray-400 hover:bg-gray-700 hover:text-white focus:outline-2 focus:outline-offset-2 focus:outline-white">
                   <span className="absolute -inset-0.5" />
                   <span className="sr-only">Open main menu</span>
@@ -82,9 +78,8 @@ export default function OpsLayout({ children }) {
                   key={item.name}
                   as={Link}
                   to={item.href}
-                  aria-current={item.current ? 'page' : undefined}
                   className={classNames(
-                    item.current
+                    location.pathname === item.href
                       ? 'bg-white text-black'
                       : 'text-white hover:bg-white hover:text-black',
                     'block rounded-md px-3 py-2 text-base font-medium',
@@ -108,7 +103,7 @@ export default function OpsLayout({ children }) {
         </Disclosure>
         <header className="py-10">
           <div className="px-4 sm:px-6 lg:px-8">
-            <h1 className="text-3xl font-bold tracking-tight text-white">Ops Home</h1>
+            <h1 className="text-3xl font-bold tracking-tight text-white">{title}</h1>
           </div>
         </header>
       </div>

--- a/src/pages/OpsInbox.jsx
+++ b/src/pages/OpsInbox.jsx
@@ -1,0 +1,163 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useUser } from '@clerk/clerk-react';
+import OpsLayout from '../layout/OpsLayout';
+import OpsAssignMenu from '../components/OpsAssignMenu.jsx';
+
+const API_URL = import.meta.env.VITE_API_URL;
+
+export default function OpsInbox() {
+  const { user } = useUser();
+  const [campaigns, setCampaigns] = useState([]);
+  const [opsUsers, setOpsUsers] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const res = await fetch(`${API_URL}/ops-users`);
+        if (!res.ok) setOpsUsers([]);
+        else {
+          const data = await res.json();
+          setOpsUsers(Array.isArray(data?.ops_users) ? data.ops_users : []);
+        }
+      } catch (e) {
+        console.error('Failed to fetch ops users', e);
+        setOpsUsers([]);
+      }
+    })();
+  }, []);
+
+  useEffect(() => {
+    if (!user) return;
+    (async () => {
+      try {
+        const res = await fetch(`${API_URL}/ops-users/${user.id}/campaigns`);
+        if (!res.ok) setCampaigns([]);
+        else {
+          const data = await res.json();
+          setCampaigns(Array.isArray(data?.campaigns) ? data.campaigns : []);
+        }
+      } catch (e) {
+        console.error('Failed to fetch campaigns', e);
+        setCampaigns([]);
+      } finally {
+        setIsLoading(false);
+      }
+    })();
+  }, [user]);
+
+  const handleAssign = async (campaignId, selected) => {
+    try {
+      const res = await fetch(`${API_URL}/ops-users/campaigns/${campaignId}/assign`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ops_user_id: selected.id }),
+      });
+      if (res.ok) {
+        setCampaigns((prev) =>
+          prev.map((c) => (c.id === campaignId ? { ...c, ops_user: selected } : c)),
+        );
+      }
+    } catch (e) {
+      console.error('Failed to assign ops user', e);
+    }
+  };
+
+  const fmt = (val) => (Array.isArray(val) ? val.join(', ') : val || '-');
+
+  return (
+    <OpsLayout title="Inbox">
+      {isLoading ? (
+        <div className="py-8 text-center text-sm text-gray-500">Loading...</div>
+      ) : campaigns.length === 0 ? (
+        <div className="py-8 text-center text-sm text-gray-500">No campaigns found.</div>
+      ) : (
+        <div className="mt-8 flow-root overflow-x-auto">
+          <table className="w-full text-left">
+            <thead className="bg-white">
+              <tr>
+                <th scope="col" className="px-3 py-3.5 text-sm font-semibold text-gray-900">
+                  Company
+                </th>
+                <th
+                  scope="col"
+                  className="hidden px-3 py-3.5 text-sm font-semibold text-gray-900 sm:table-cell"
+                >
+                  Type
+                </th>
+                <th
+                  scope="col"
+                  className="hidden px-3 py-3.5 text-sm font-semibold text-gray-900 md:table-cell"
+                >
+                  Budget
+                </th>
+                <th scope="col" className="px-3 py-3.5 text-sm font-semibold text-gray-900">
+                  Created By
+                </th>
+                <th scope="col" className="px-3 py-3.5 text-sm font-semibold text-gray-900">
+                  Assigned To
+                </th>
+                <th scope="col" className="px-3 py-3.5 text-sm font-semibold text-gray-900">
+                  Status
+                </th>
+                <th scope="col" className="py-3.5 pl-3 pr-4 sm:pr-6">
+                  <span className="sr-only">View</span>
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200">
+              {campaigns.map((c) => (
+                <tr key={c.id}>
+                  <td className="whitespace-nowrap px-3 py-4 text-sm font-medium text-gray-900">
+                    {c.company_name || '-'}
+                  </td>
+                  <td className="hidden whitespace-nowrap px-3 py-4 text-sm text-gray-500 sm:table-cell">
+                    {fmt(c.campaign_type)}
+                  </td>
+                  <td className="hidden whitespace-nowrap px-3 py-4 text-sm text-gray-500 md:table-cell">
+                    {c.ooh_budget_range || '-'}
+                  </td>
+                  <td className="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
+                    {c.created_by ? (
+                      <div className="flex items-center">
+                        {c.created_by.image_url ? (
+                          <img
+                            src={c.created_by.image_url}
+                            alt={c.created_by.email}
+                            className="mr-2 h-6 w-6 rounded-full"
+                          />
+                        ) : null}
+                        {c.created_by.email}
+                      </div>
+                    ) : (
+                      '-'
+                    )}
+                  </td>
+                  <td className="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
+                    <OpsAssignMenu
+                      current={c.ops_user}
+                      opsUsers={opsUsers}
+                      onSelect={(u) => handleAssign(c.id, u)}
+                    />
+                  </td>
+                  <td className="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
+                    {c.status || '-'}
+                  </td>
+                  <td className="whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
+                    <Link
+                      to={`/campaigns/${c.id}`}
+                      className="text-indigo-600 hover:text-indigo-900"
+                    >
+                      View<span className="sr-only">, {c.company_name}</span>
+                    </Link>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </OpsLayout>
+  );
+}


### PR DESCRIPTION
## Summary
- add dropdown to assign campaigns to ops users with avatars
- show campaign creator and assignment controls in ops view and inbox
- add inbox page and navigation for ops users

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68af756063fc832e9edf5e5dd6fd91e8