### PR TITLE
feat: ops campaign detail with assignment options

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,6 +19,7 @@ import Support from './pages/Support';
 import Contact from './pages/Contact';
 import OpsHome from './pages/OpsHome';
 import OpsInbox from './pages/OpsInbox.jsx';
+import OpsCampaignDetail from './pages/OpsCampaignDetail.jsx';
 import ProtectedRoute from './components/ProtectedRoute';
 import Pricing from './pages/Pricing';
 
@@ -47,6 +48,7 @@ function App() {
         <Route path="/pricing" element={<Pricing />} />
         <Route path="/ops" element={<ProtectedRoute><OpsHome /></ProtectedRoute>} />
         <Route path="/ops/inbox" element={<ProtectedRoute><OpsInbox /></ProtectedRoute>} />
+        <Route path="/ops/campaigns/:id/*" element={<ProtectedRoute><OpsCampaignDetail /></ProtectedRoute>} />
       </Routes>
     </>
   );

--- a/src/components/OpsAssignMenu.jsx
+++ b/src/components/OpsAssignMenu.jsx
@@ -2,23 +2,13 @@ import { Menu, MenuButton, MenuItem, MenuItems } from '@headlessui/react';
 import { ChevronDownIcon } from '@heroicons/react/20/solid';
 
 export default function OpsAssignMenu({ current, opsUsers = [], onSelect }) {
-  return (
-    <Menu as="div" className="relative inline-block text-left">
+  // Stop row click navigation when interacting with the menu
+  const stop = (e) => e.stopPropagation();
+
+  const renderMenu = (label) => (
+    <Menu as="div" className="relative inline-block text-left" onClick={stop}>
       <MenuButton className="inline-flex w-full justify-center gap-x-1.5 rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50">
-        {current ? (
-          <span className="flex items-center">
-            {current.image_url ? (
-              <img
-                src={current.image_url}
-                alt={current.email}
-                className="mr-2 h-5 w-5 rounded-full"
-              />
-            ) : null}
-            {current.email || 'Assign'}
-          </span>
-        ) : (
-          'Assign'
-        )}
+        {label}
         <ChevronDownIcon aria-hidden="true" className="-mr-1 h-5 w-5 text-gray-400" />
       </MenuButton>
       <MenuItems className="absolute right-0 z-10 mt-2 w-56 origin-top-right divide-y divide-gray-100 rounded-md bg-white shadow-lg outline-1 outline-black/5">
@@ -47,4 +37,22 @@ export default function OpsAssignMenu({ current, opsUsers = [], onSelect }) {
       </MenuItems>
     </Menu>
   );
+
+  if (current) {
+    return (
+      <div className="flex items-center" onClick={stop}>
+        {current.image_url ? (
+          <img
+            src={current.image_url}
+            alt={current.email}
+            className="mr-2 h-5 w-5 rounded-full"
+          />
+        ) : null}
+        <span className="mr-2 text-sm text-gray-900">{current.email}</span>
+        {renderMenu('Reassign')}
+      </div>
+    );
+  }
+
+  return renderMenu('Assign');
 }

--- a/src/pages/CampaignInfo.jsx
+++ b/src/pages/CampaignInfo.jsx
@@ -58,24 +58,34 @@ function StatusPill({ value }) {
   return <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ring-1 ${cls}`}>{value}</span>;
 }
 
-export default function CampaignInfo() {
+export default function CampaignInfo({ ops = false }) {
   const { id } = useParams();
   const { user } = useUser();
   const [campaign, setCampaign] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
-    if (!user) return;
     (async () => {
       setIsLoading(true);
       try {
-        const res = await fetch(`${API_URL}/users/${user.id}/campaigns`);
-        if (res.ok) {
-          const data = await res.json();
-          const found = (data.campaigns || []).find((c) => c.id === id);
-          setCampaign(found || null);
+        if (ops) {
+          const res = await fetch(`${API_URL}/campaigns/${id}`);
+          if (res.ok) {
+            const data = await res.json();
+            setCampaign(data.campaign || data || null);
+          } else {
+            setCampaign(null);
+          }
         } else {
-          setCampaign(null);
+          if (!user) return;
+          const res = await fetch(`${API_URL}/users/${user.id}/campaigns`);
+          if (res.ok) {
+            const data = await res.json();
+            const found = (data.campaigns || []).find((c) => c.id === id);
+            setCampaign(found || null);
+          } else {
+            setCampaign(null);
+          }
         }
       } catch (err) {
         console.error('Failed to load campaign', err);
@@ -84,7 +94,7 @@ export default function CampaignInfo() {
         setIsLoading(false);
       }
     })();
-  }, [user, id]);
+  }, [ops, user, id]);
 
   if (isLoading) {
     return (

--- a/src/pages/OpsCampaignDetail.jsx
+++ b/src/pages/OpsCampaignDetail.jsx
@@ -1,0 +1,67 @@
+import OpsLayout from '../layout/OpsLayout';
+import { NavLink, Routes, Route, Navigate, useParams } from 'react-router-dom';
+import CampaignInfo from './CampaignInfo';
+import CampaignQuotes from './CampaignQuotes';
+import CampaignCreative from './CampaignCreative';
+import CampaignProgress from './CampaignProgress';
+import CampaignReports from './CampaignReports';
+
+function classNames(...classes) {
+  return classes.filter(Boolean).join(' ');
+}
+
+export default function OpsCampaignDetail() {
+  const { id } = useParams();
+  const navigation = [
+    { name: 'Details', to: 'details' },
+    { name: 'Quotes', to: 'quotes' },
+    { name: 'Creative', to: 'creative' },
+    { name: 'View Campaign Progress', short: 'Progress', to: 'progress' },
+    { name: 'Reports', to: 'reports' },
+  ];
+
+  return (
+    <OpsLayout title="Campaign">
+      <div className="mx-auto w-full max-w-4xl px-4 sm:px-6 lg:px-8">
+        <nav className="mt-6 rounded-xl border border-[#1f6fa5]/30 bg-[#288dcf] shadow-sm">
+          <div className="flex flex-wrap items-center justify-center gap-2 px-2 py-2 sm:px-3">
+            {navigation.map((item) => (
+              <NavLink
+                key={item.to}
+                to={`/ops/campaigns/${id}/${item.to}`}
+                className={({ isActive }) =>
+                  classNames(
+                    'whitespace-nowrap rounded-md px-3 py-1.5 text-sm font-semibold transition-colors',
+                    isActive
+                      ? 'bg-[#1f6fa5] text-white shadow-sm'
+                      : 'text-white/95 hover:bg-[#2f9ff0] hover:text-white'
+                  )
+                }
+                end
+              >
+                {item.short ? (
+                  <>
+                    <span className="sm:hidden">{item.short}</span>
+                    <span className="hidden sm:inline">{item.name}</span>
+                  </>
+                ) : (
+                  item.name
+                )}
+              </NavLink>
+            ))}
+          </div>
+        </nav>
+        <div className="py-5">
+          <Routes>
+            <Route path="details" element={<CampaignInfo ops />} />
+            <Route path="quotes" element={<CampaignQuotes ops />} />
+            <Route path="creative" element={<CampaignCreative ops />} />
+            <Route path="progress" element={<CampaignProgress ops />} />
+            <Route path="reports" element={<CampaignReports ops />} />
+            <Route index element={<Navigate to={`/ops/campaigns/${id}/details`} replace />} />
+          </Routes>
+        </div>
+      </div>
+    </OpsLayout>
+  );
+}

--- a/src/pages/OpsHome.jsx
+++ b/src/pages/OpsHome.jsx
@@ -2,11 +2,12 @@ import OpsLayout from '../layout/OpsLayout';
 import CampaignsOpsStats from '../components/CampaignsOpsStats';
 import OpsAssignMenu from '../components/OpsAssignMenu.jsx';
 import { useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 const API_URL = import.meta.env.VITE_API_URL;
 
 export default function OpsHome() {
+  const navigate = useNavigate();
   const [campaigns, setCampaigns] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
   const [opsUsers, setOpsUsers] = useState([]);
@@ -101,14 +102,15 @@ export default function OpsHome() {
                   <th scope="col" className="px-3 py-3.5 text-sm font-semibold text-gray-900">
                     Status
                   </th>
-                  <th scope="col" className="py-3.5 pl-3 pr-4 sm:pr-6">
-                    <span className="sr-only">View</span>
-                  </th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-gray-200">
                 {campaigns.map((c) => (
-                  <tr key={c.id}>
+                  <tr
+                    key={c.id}
+                    onClick={() => navigate(`/ops/campaigns/${c.id}`)}
+                    className="cursor-pointer hover:bg-gray-50"
+                  >
                     <td className="whitespace-nowrap px-3 py-4 text-sm font-medium text-gray-900">
                       {c.company_name || '-'}
                     </td>
@@ -143,14 +145,6 @@ export default function OpsHome() {
                     </td>
                     <td className="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
                       {c.status || '-'}
-                    </td>
-                    <td className="whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
-                      <Link
-                        to={`/campaigns/${c.id}`}
-                        className="text-indigo-600 hover:text-indigo-900"
-                      >
-                        View<span className="sr-only">, {c.company_name}</span>
-                      </Link>
                     </td>
                   </tr>
                 ))}

--- a/src/pages/OpsInbox.jsx
+++ b/src/pages/OpsInbox.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { useUser } from '@clerk/clerk-react';
 import OpsLayout from '../layout/OpsLayout';
 import OpsAssignMenu from '../components/OpsAssignMenu.jsx';
@@ -8,6 +8,7 @@ const API_URL = import.meta.env.VITE_API_URL;
 
 export default function OpsInbox() {
   const { user } = useUser();
+  const navigate = useNavigate();
   const [campaigns, setCampaigns] = useState([]);
   const [opsUsers, setOpsUsers] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -101,14 +102,15 @@ export default function OpsInbox() {
                 <th scope="col" className="px-3 py-3.5 text-sm font-semibold text-gray-900">
                   Status
                 </th>
-                <th scope="col" className="py-3.5 pl-3 pr-4 sm:pr-6">
-                  <span className="sr-only">View</span>
-                </th>
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-200">
               {campaigns.map((c) => (
-                <tr key={c.id}>
+                <tr
+                  key={c.id}
+                  onClick={() => navigate(`/ops/campaigns/${c.id}`)}
+                  className="cursor-pointer hover:bg-gray-50"
+                >
                   <td className="whitespace-nowrap px-3 py-4 text-sm font-medium text-gray-900">
                     {c.company_name || '-'}
                   </td>
@@ -143,14 +145,6 @@ export default function OpsInbox() {
                   </td>
                   <td className="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
                     {c.status || '-'}
-                  </td>
-                  <td className="whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
-                    <Link
-                      to={`/campaigns/${c.id}`}
-                      className="text-indigo-600 hover:text-indigo-900"
-                    >
-                      View<span className="sr-only">, {c.company_name}</span>
-                    </Link>
                   </td>
                 </tr>
               ))}


### PR DESCRIPTION
## Summary
- show assigned ops user with avatar and reassign menu in Ops tables
- make Ops campaign rows open a detailed view under Ops layout
- allow campaign info to fetch single campaign for ops views

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af809d0680832ebbb578c68c7fc7f8