### PR TITLE
Fix ops assignment and dropdown styling

### DIFF
--- a/src/components/OpsAssignMenu.jsx
+++ b/src/components/OpsAssignMenu.jsx
@@ -11,8 +11,8 @@ export default function OpsAssignMenu({ current, opsUsers = [], onSelect }) {
         {label}
         <ChevronDownIcon aria-hidden="true" className="-mr-1 h-5 w-5 text-gray-400" />
       </MenuButton>
-      <MenuItems className="absolute right-0 z-10 mt-2 w-56 origin-top-right divide-y divide-gray-100 rounded-md bg-white shadow-lg outline-1 outline-black/5">
-        <div className="max-h-60 overflow-y-auto py-1">
+      <MenuItems className="absolute right-0 z-10 mt-2 w-64 origin-top-right divide-y divide-gray-100 rounded-md bg-white shadow-lg ring-1 ring-black/5">
+        <div className="py-1">
           {opsUsers.map((u) => (
             <MenuItem key={u.id}>
               {({ active }) => (

--- a/src/pages/OpsHome.jsx
+++ b/src/pages/OpsHome.jsx
@@ -51,7 +51,8 @@ export default function OpsHome() {
       const res = await fetch(`${API_URL}/ops-users/campaigns/${campaignId}/assign`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ ops_user_id: user.id }),
+        credentials: 'include',
+        body: JSON.stringify({ user_id: user.id }),
       });
       if (res.ok) {
         setCampaigns((prev) =>

--- a/src/pages/OpsInbox.jsx
+++ b/src/pages/OpsInbox.jsx
@@ -53,7 +53,8 @@ export default function OpsInbox() {
       const res = await fetch(`${API_URL}/ops-users/campaigns/${campaignId}/assign`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ ops_user_id: selected.id }),
+        credentials: 'include',
+        body: JSON.stringify({ user_id: selected.id }),
       });
       if (res.ok) {
         setCampaigns((prev) =>


### PR DESCRIPTION
## Summary
- send user id with credentials when assigning campaigns to ops users
- expand assignment dropdown and remove inner scroll bars

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68af845ba7b4832ea5f5e72869e9943e