### PR TITLE
feat: cache ops user check

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -21,6 +21,7 @@ import OpsHome from './pages/OpsHome';
 import OpsInbox from './pages/OpsInbox.jsx';
 import OpsCampaignDetail from './pages/OpsCampaignDetail.jsx';
 import ProtectedRoute from './components/ProtectedRoute';
+import OpsProtectedRoute from './components/OpsProtectedRoute.jsx';
 import Pricing from './pages/Pricing';
 
 function App() {
@@ -46,9 +47,9 @@ function App() {
         <Route path="/terms" element={<TermsOfService />} />
         <Route path="/privacy" element={<PrivacyPolicy />} />
         <Route path="/pricing" element={<Pricing />} />
-        <Route path="/ops" element={<ProtectedRoute><OpsHome /></ProtectedRoute>} />
-        <Route path="/ops/inbox" element={<ProtectedRoute><OpsInbox /></ProtectedRoute>} />
-        <Route path="/ops/campaigns/:id/*" element={<ProtectedRoute><OpsCampaignDetail /></ProtectedRoute>} />
+        <Route path="/ops" element={<OpsProtectedRoute><OpsHome /></OpsProtectedRoute>} />
+        <Route path="/ops/inbox" element={<OpsProtectedRoute><OpsInbox /></OpsProtectedRoute>} />
+        <Route path="/ops/campaigns/:id/*" element={<OpsProtectedRoute><OpsCampaignDetail /></OpsProtectedRoute>} />
       </Routes>
     </>
   );

--- a/src/components/OpsProtectedRoute.jsx
+++ b/src/components/OpsProtectedRoute.jsx
@@ -1,0 +1,10 @@
+import { Navigate } from 'react-router-dom';
+import ProtectedRoute from './ProtectedRoute.jsx';
+import useIsOpsUser from '../hooks/useIsOpsUser.js';
+
+export default function OpsProtectedRoute({ children }) {
+  const { isOpsUser, loading } = useIsOpsUser();
+  if (loading) return null;
+  if (!isOpsUser) return <Navigate to="/dashboard" replace />;
+  return <ProtectedRoute>{children}</ProtectedRoute>;
+}

--- a/src/hooks/useIsOpsUser.js
+++ b/src/hooks/useIsOpsUser.js
@@ -1,0 +1,58 @@
+import { useEffect, useState } from 'react';
+import { useUser } from '@clerk/clerk-react';
+
+const API_URL = import.meta.env.VITE_API_URL;
+const CACHE_TTL_MS = 30 * 60 * 1000; // 30 minutes
+
+export default function useIsOpsUser() {
+  const { user } = useUser();
+  const [isOpsUser, setIsOpsUser] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!user) return;
+    const key = `is_ops_user:${user.id}`;
+    try {
+      const cached = localStorage.getItem(key);
+      if (cached) {
+        const { value, exp } = JSON.parse(cached);
+        if (exp > Date.now()) {
+          setIsOpsUser(Boolean(value));
+          setLoading(false);
+          return;
+        }
+      }
+    } catch (e) {
+      /* ignore malformed cache */
+    }
+
+    const controller = new AbortController();
+    (async () => {
+      try {
+        const res = await fetch(`${API_URL}/ops-users/${user.id}/check`, {
+          credentials: 'include',
+          signal: controller.signal,
+        });
+        const data = res.ok ? await res.json() : { is_ops_user: false };
+        const value = Boolean(data?.is_ops_user);
+        setIsOpsUser(value);
+        try {
+          localStorage.setItem(
+            key,
+            JSON.stringify({ value, exp: Date.now() + CACHE_TTL_MS })
+          );
+        } catch (e) {
+          /* ignore storage errors */
+        }
+      } catch (e) {
+        setIsOpsUser(false);
+      } finally {
+        setLoading(false);
+      }
+    })();
+
+    return () => controller.abort();
+  }, [user]);
+
+  return { isOpsUser, loading };
+}

--- a/src/layout/InternalLayout.jsx
+++ b/src/layout/InternalLayout.jsx
@@ -20,6 +20,7 @@ import {
 } from '@heroicons/react/24/outline';
 import { UserButton, SignOutButton } from '@clerk/clerk-react';
 import OpsToggle from '../components/OpsToggle.jsx';
+import useIsOpsUser from '../hooks/useIsOpsUser.js';
 import { withBase } from '../utils/basePath.js';
 
 const navigation = [
@@ -41,6 +42,7 @@ function classNames(...classes) {
 export default function InternalLayout({ children }) {
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const { pathname } = useLocation();
+  const { isOpsUser } = useIsOpsUser();
 
   // treat a nav item as active for nested routes too
   const isActive = (href) => pathname === href || pathname.startsWith(href + '/');
@@ -197,7 +199,7 @@ export default function InternalLayout({ children }) {
             <div className="flex flex-1 justify-end gap-x-4 self-stretch lg:gap-x-6">
               <div className="flex items-center gap-x-4 lg:gap-x-6">
                 {/* notifications placeholder */}
-                {pathname === '/dashboard' && (
+                {pathname === '/dashboard' && isOpsUser && (
                   <>
                     <OpsToggle />
                     <div aria-hidden="true" className="hidden lg:block lg:h-6 lg:w-px lg:bg-gray-200" />


### PR DESCRIPTION
## Summary
- cache ops user status in localStorage
- add OpsProtectedRoute and gate Ops routes
- show Ops toggle only for ops users

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af9db39d8c832ea0a8162071b2eb63