### PR TITLE
feat: show user avatars with names

### DIFF
--- a/src/components/OpsAssignMenu.jsx
+++ b/src/components/OpsAssignMenu.jsx
@@ -8,6 +8,7 @@ import {
   Transition,
 } from '@headlessui/react';
 import { ChevronDownIcon } from '@heroicons/react/20/solid';
+import UserAvatarName from './UserAvatarName.jsx';
 
 function cls(...xs) {
   return xs.filter(Boolean).join(' ');
@@ -47,7 +48,7 @@ export default function OpsAssignMenu({ current, opsUsers = [], onSelect }) {
 
   const Portal = ({ children }) => ReactDOM.createPortal(children, document.body);
 
-  const labelFor = (u) => u?.email || u?.full_name || u?.user_id || u?.id || 'user';
+  const labelFor = (u) => u?.full_name || u?.email || u?.user_id || u?.id || 'user';
 
   const ButtonContent = ({ label }) => (
     <>
@@ -57,17 +58,13 @@ export default function OpsAssignMenu({ current, opsUsers = [], onSelect }) {
   );
 
   const LabelWhenAssigned = () => (
-    <div className="flex items-center" onClick={stop}>
-      {resolvedCurrent?.image_url ? (
-        <img
-          src={resolvedCurrent.image_url}
-          alt={labelFor(resolvedCurrent)}
-          className="mr-2 h-5 w-5 rounded-full"
-        />
-      ) : null}
-      <span className="mr-2 max-w-[14rem] truncate text-sm text-gray-900">
-        {labelFor(resolvedCurrent)}
-      </span>
+    <div className="mr-2" onClick={stop}>
+      <UserAvatarName
+        user={resolvedCurrent}
+        size="xs"
+        className="max-w-[14rem]"
+        textClass="text-sm text-gray-900"
+      />
     </div>
   );
 

--- a/src/components/UserAvatarName.jsx
+++ b/src/components/UserAvatarName.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+
+/**
+ * Displays a user's avatar and full name.
+ * Expects a user object with optional `image_url`, `full_name`, `email`, `first_name`, `last_name`, `user_id` fields.
+ *
+ * @param {object} props
+ * @param {object} props.user - The user data.
+ * @param {string} [props.size="sm"] - Avatar size: "xs", "sm", "md", or "lg".
+ * @param {string} [props.className] - Additional classes for the container.
+ * @param {string} [props.textClass] - Additional classes for the text element.
+ */
+export default function UserAvatarName({ user, size = 'sm', className = '', textClass = '' }) {
+  if (!user) return null;
+
+  const src = user.image_url || user.imageUrl || null;
+  const name =
+    user.full_name ||
+    user.fullName ||
+    [user.first_name || user.firstName, user.last_name || user.lastName].filter(Boolean).join(' ') ||
+    user.email ||
+    user.user_id ||
+    user.id ||
+    '';
+
+  const sizes = {
+    xs: 'h-4 w-4',
+    sm: 'h-5 w-5',
+    md: 'h-6 w-6',
+    lg: 'h-8 w-8',
+  };
+  const avatarCls = sizes[size] || sizes.sm;
+
+  return (
+    <div className={`flex items-center ${className}`}>
+      {src ? <img src={src} alt={name || 'avatar'} className={`${avatarCls} rounded-full mr-2`} /> : null}
+      <span className={`truncate ${textClass}`}>{name}</span>
+    </div>
+  );
+}

--- a/src/pages/CampaignInfo.jsx
+++ b/src/pages/CampaignInfo.jsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router-dom';
 import { useUser } from '@clerk/clerk-react';
 import { PaperClipIcon } from '@heroicons/react/20/solid';
 import Lottie from 'lottie-react';
+import UserAvatarName from '../components/UserAvatarName.jsx';
 import loadingAnim from '../assets/loading.json';
 
 const API_URL = import.meta.env.VITE_API_URL;
@@ -112,6 +113,9 @@ export default function CampaignInfo({ ops = false }) {
     campaign.created_at || campaign.createdAt || campaign.created ||
     campaign.submitted_at || campaign.submittedAt || null;
   const status = campaign.status || campaign.campaign_status || null;
+  const createdBy = campaign.created_by || campaign.createdBy || null;
+  const assignedTo =
+    campaign.assigned_to || campaign.assignedTo || campaign.ops_user || null;
 
   // Parse Target Location Attachment (render only if present & non-empty)
   const tlaRaw =
@@ -196,6 +200,22 @@ export default function CampaignInfo({ ops = false }) {
 
       {/* MOBILE: card grid (labels above values) */}
       <div className="px-4 pb-4 grid grid-cols-1 gap-3 sm:hidden">
+        {createdBy && (
+          <div className="rounded-xl ring-1 ring-gray-200 bg-white px-4 py-3">
+            <div className="text-xs font-medium text-gray-500">Created By</div>
+            <div className="mt-1 text-sm font-medium text-gray-900 break-words break-all">
+              <UserAvatarName user={createdBy} />
+            </div>
+          </div>
+        )}
+        {assignedTo && (
+          <div className="rounded-xl ring-1 ring-gray-200 bg-white px-4 py-3">
+            <div className="text-xs font-medium text-gray-500">Assigned To</div>
+            <div className="mt-1 text-sm font-medium text-gray-900 break-words break-all">
+              <UserAvatarName user={assignedTo} />
+            </div>
+          </div>
+        )}
         {prioritized.map((f) => (
           <div
             key={`m-${f.key}`}
@@ -212,6 +232,22 @@ export default function CampaignInfo({ ops = false }) {
       {/* DESKTOP/TABLET: definition list */}
       <div className="hidden sm:block border-t border-gray-100">
         <dl className="divide-y divide-gray-100">
+          {createdBy && (
+            <div className="px-4 py-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
+              <dt className="text-sm font-medium text-gray-900">Created By</dt>
+              <dd className="mt-1 text-sm leading-6 text-gray-700 sm:col-span-2 sm:mt-0">
+                <UserAvatarName user={createdBy} />
+              </dd>
+            </div>
+          )}
+          {assignedTo && (
+            <div className="px-4 py-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
+              <dt className="text-sm font-medium text-gray-900">Assigned To</dt>
+              <dd className="mt-1 text-sm leading-6 text-gray-700 sm:col-span-2 sm:mt-0">
+                <UserAvatarName user={assignedTo} />
+              </dd>
+            </div>
+          )}
           {allFields.map((field) => (
             <div key={field.key} className="px-4 py-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
               <dt className="text-sm font-medium text-gray-900">{field.label}</dt>

--- a/src/pages/OpsHome.jsx
+++ b/src/pages/OpsHome.jsx
@@ -1,6 +1,7 @@
 import OpsLayout from '../layout/OpsLayout';
 import CampaignsOpsStats from '../components/CampaignsOpsStats';
 import OpsAssignMenu from '../components/OpsAssignMenu.jsx';
+import UserAvatarName from '../components/UserAvatarName.jsx';
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
@@ -157,18 +158,8 @@ export default function OpsHome() {
 
                     <td className="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
                       {c.created_by ? (
-                        <div className="flex items-center">
-                          {c.created_by.image_url ? (
-                            <img
-                              src={c.created_by.image_url}
-                              alt={c.created_by.email ?? 'avatar'}
-                              className="mr-2 h-6 w-6 rounded-full"
-                              onClick={(e) => e.stopPropagation()}
-                            />
-                          ) : null}
-                          <span onClick={(e) => e.stopPropagation()}>
-                            {c.created_by.email ?? c.created_by.full_name ?? c.created_by.user_id}
-                          </span>
+                        <div onClick={(e) => e.stopPropagation()}>
+                          <UserAvatarName user={c.created_by} size="md" />
                         </div>
                       ) : (
                         '-'

--- a/src/pages/OpsInbox.jsx
+++ b/src/pages/OpsInbox.jsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { useUser } from '@clerk/clerk-react';
 import OpsLayout from '../layout/OpsLayout';
 import OpsAssignMenu from '../components/OpsAssignMenu.jsx';
+import UserAvatarName from '../components/UserAvatarName.jsx';
 
 const API_URL = import.meta.env.VITE_API_URL;
 
@@ -123,16 +124,7 @@ export default function OpsInbox() {
                   </td>
                   <td className="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
                     {c.created_by ? (
-                      <div className="flex items-center">
-                        {c.created_by.image_url ? (
-                          <img
-                            src={c.created_by.image_url}
-                            alt={c.created_by.email}
-                            className="mr-2 h-6 w-6 rounded-full"
-                          />
-                        ) : null}
-                        {c.created_by.email}
-                      </div>
+                      <UserAvatarName user={c.created_by} size="md" />
                     ) : (
                       '-'
                     )}


### PR DESCRIPTION
## Summary
- add reusable UserAvatarName component
- display creator and assignee avatars across campaign pages
- prioritize full names in OpsAssignMenu

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68afa08fba80832ebb5ee31ff08725b7