### PR TITLE
Refactor ops campaign lists into shared card

### DIFF
--- a/src/components/OpsAssignMenu.jsx
+++ b/src/components/OpsAssignMenu.jsx
@@ -7,7 +7,6 @@ import {
   MenuItems,
   Transition,
 } from '@headlessui/react';
-import { ChevronDownIcon } from '@heroicons/react/20/solid';
 import { ArrowsRightLeftIcon, UserPlusIcon } from '@heroicons/react/24/outline';
 import UserAvatarName from './UserAvatarName.jsx';
 
@@ -33,9 +32,6 @@ export default function OpsAssignMenu({ current, opsUsers = [], onSelect }) {
     return { user_id: uid, ...fromList, ...current };
   }, [current, normalized]);
 
-  // prevent row navigation when clicking inside the control
-  const stop = (e) => e.stopPropagation();
-
   const recalc = () => {
     const el = buttonRef.current;
     if (!el) return;
@@ -52,7 +48,7 @@ export default function OpsAssignMenu({ current, opsUsers = [], onSelect }) {
   const labelFor = (u) => u?.full_name || u?.email || u?.user_id || u?.id || 'user';
 
   const LabelWhenAssigned = () => (
-    <div className="mr-2" onClick={stop}>
+    <div className="mr-2">
       <UserAvatarName
         user={resolvedCurrent}
         size="xs"
@@ -62,8 +58,8 @@ export default function OpsAssignMenu({ current, opsUsers = [], onSelect }) {
     </div>
   );
 
-   return (
-     <Menu as="div" className="relative inline-flex items-center gap-2" onClick={stop}>
+  return (
+    <Menu as="div" className="relative inline-flex items-center gap-2">
       {({ open }) => {
         useLayoutEffect(() => {
           if (open) {
@@ -84,6 +80,7 @@ export default function OpsAssignMenu({ current, opsUsers = [], onSelect }) {
 
             <MenuButton
               ref={buttonRef}
+              onClick={(e) => e.stopPropagation()}
               className={cls(
                 'inline-flex items-center rounded-md border border-gray-300 bg-white px-2.5 py-1.5 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500'
               )}

--- a/src/components/OpsCampaignTable.jsx
+++ b/src/components/OpsCampaignTable.jsx
@@ -1,0 +1,112 @@
+import Card from './Card';
+import OpsAssignMenu from './OpsAssignMenu.jsx';
+import UserAvatarName from './UserAvatarName.jsx';
+
+function cls(...xs) {
+  return xs.filter(Boolean).join(' ');
+}
+
+export default function OpsCampaignTable({
+  title,
+  campaigns = [],
+  opsUsers = [],
+  onAssign,
+  onRowClick,
+  isLoading = false,
+  sticky = false,
+  className = '',
+}) {
+  const fmt = (val) => (Array.isArray(val) ? val.join(', ') : val || '-');
+
+  if (isLoading) {
+    return (
+      <Card title={title} className={className}>
+        <div className="py-8 text-center text-sm text-gray-500">Loading...</div>
+      </Card>
+    );
+  }
+
+  if (!campaigns.length) {
+    return (
+      <Card title={title} className={className}>
+        <div className="py-8 text-center text-sm text-gray-500">No campaigns found.</div>
+      </Card>
+    );
+  }
+
+  return (
+    <Card title={title} className={className}>
+      <div className="overflow-x-auto">
+        <table className="w-full text-left">
+          <thead className="bg-white">
+            <tr>
+              <th className="px-3 py-3.5 text-sm font-semibold text-gray-900">Company</th>
+              <th className="hidden px-3 py-3.5 text-sm font-semibold text-gray-900 sm:table-cell">Type</th>
+              <th className="hidden px-3 py-3.5 text-sm font-semibold text-gray-900 md:table-cell">Budget</th>
+              <th className="px-3 py-3.5 text-sm font-semibold text-gray-900">Created By</th>
+              <th
+                className={cls(
+                  'px-3 py-3.5 text-sm font-semibold text-gray-900',
+                  sticky ? 'lg:sticky lg:right-24 lg:bg-white' : ''
+                )}
+              >
+                Assigned To
+              </th>
+              <th
+                className={cls(
+                  'px-3 py-3.5 text-sm font-semibold text-gray-900',
+                  sticky ? 'lg:sticky lg:right-0 lg:bg-white' : ''
+                )}
+              >
+                Status
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-200">
+            {campaigns.map((c) => (
+              <tr
+                key={c.id}
+                onClick={() => onRowClick && onRowClick(c.id)}
+                className="cursor-pointer hover:bg-gray-50"
+              >
+                <td className="whitespace-nowrap px-3 py-4 text-sm font-medium text-gray-900">
+                  {c.company_name || '-'}
+                </td>
+                <td className="hidden whitespace-nowrap px-3 py-4 text-sm text-gray-500 sm:table-cell">
+                  {fmt(c.campaign_type)}
+                </td>
+                <td className="hidden whitespace-nowrap px-3 py-4 text-sm text-gray-500 md:table-cell">
+                  {c.ooh_budget_range || '-'}
+                </td>
+                <td className="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
+                  {c.created_by ? <UserAvatarName user={c.created_by} size="md" /> : '-'}
+                </td>
+                <td
+                  className={cls(
+                    'whitespace-nowrap px-3 py-4 text-sm text-gray-500',
+                    sticky ? 'lg:sticky lg:right-24 lg:bg-white' : ''
+                  )}
+                >
+                  <OpsAssignMenu
+                    current={c.assigned_to ?? c.ops_user ?? null}
+                    opsUsers={opsUsers}
+                    onSelect={(u) => onAssign && onAssign(c.id, u)}
+                  />
+                </td>
+                <td
+                  className={cls(
+                    'whitespace-nowrap px-3 py-4 text-sm text-gray-500',
+                    sticky ? 'lg:sticky lg:right-0 lg:bg-white' : ''
+                  )}
+                >
+                  {c.status || '-'}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </Card>
+  );
+}
+

--- a/src/pages/OpsHome.jsx
+++ b/src/pages/OpsHome.jsx
@@ -1,7 +1,6 @@
 import OpsLayout from '../layout/OpsLayout';
 import CampaignsOpsStats from '../components/CampaignsOpsStats';
-import OpsAssignMenu from '../components/OpsAssignMenu.jsx';
-import UserAvatarName from '../components/UserAvatarName.jsx';
+import OpsCampaignTable from '../components/OpsCampaignTable.jsx';
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
@@ -171,87 +170,19 @@ export default function OpsHome() {
     }
   };
 
-  const fmt = (val) => (Array.isArray(val) ? val.join(', ') : val || '-');
-
   return (
     <OpsLayout title="Campaigns">
       <CampaignsOpsStats campaigns={campaigns} />
-
-      {isLoading ? (
-        <div className="py-8 text-center text-sm text-gray-500">Loading...</div>
-      ) : campaigns.length === 0 ? (
-        <div className="py-8 text-center text-sm text-gray-500">No campaigns found.</div>
-      ) : (
-        <div className="mt-6 overflow-x-auto">
-          <table className="w-full text-left">
-            <thead className="bg-white">
-              <tr>
-                <th className="px-3 py-3.5 text-sm font-semibold text-gray-900">Company</th>
-                <th className="hidden px-3 py-3.5 text-sm font-semibold text-gray-900 sm:table-cell">
-                  Type
-                </th>
-                <th className="hidden px-3 py-3.5 text-sm font-semibold text-gray-900 md:table-cell">
-                  Budget
-                </th>
-                <th className="px-3 py-3.5 text-sm font-semibold text-gray-900">Created By</th>
-                <th className="px-3 py-3.5 text-sm font-semibold text-gray-900 lg:sticky lg:right-24 lg:bg-white">
-                  Assigned To
-                </th>
-                <th className="px-3 py-3.5 text-sm font-semibold text-gray-900 lg:sticky lg:right-0 lg:bg-white">
-                  Status
-                </th>
-              </tr>
-            </thead>
-
-            <tbody className="divide-y divide-gray-200">
-              {campaigns.map((c) => (
-                <tr
-                  key={c.id}
-                  onClick={() => navigate(`/ops/campaigns/${c.id}`)}
-                  className="cursor-pointer hover:bg-gray-50"
-                >
-                  <td className="whitespace-nowrap px-3 py-4 text-sm font-medium text-gray-900">
-                    {c.company_name || '-'}
-                  </td>
-
-                  <td className="hidden whitespace-nowrap px-3 py-4 text-sm text-gray-500 sm:table-cell">
-                    {fmt(c.campaign_type)}
-                  </td>
-
-                  <td className="hidden whitespace-nowrap px-3 py-4 text-sm text-gray-500 md:table-cell">
-                    {c.ooh_budget_range || '-'}
-                  </td>
-
-                  <td className="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
-                    {c.created_by ? (
-                      <div onClick={(e) => e.stopPropagation()}>
-                        <UserAvatarName user={c.created_by} size="md" />
-                      </div>
-                    ) : (
-                      '-'
-                    )}
-                  </td>
-
-                  <td
-                    className="whitespace-nowrap px-3 py-4 text-sm text-gray-500 lg:sticky lg:right-24 lg:bg-white"
-                    onClick={(e) => e.stopPropagation()}
-                  >
-                    <OpsAssignMenu
-                      current={c.assigned_to ?? c.ops_user ?? null}
-                      opsUsers={opsUsers}
-                      onSelect={(u) => handleAssign(c.id, u)}
-                    />
-                  </td>
-
-                  <td className="whitespace-nowrap px-3 py-4 text-sm text-gray-500 lg:sticky lg:right-0 lg:bg-white">
-                    {c.status || '-'}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      )}
+      <OpsCampaignTable
+        title="Campaigns"
+        campaigns={campaigns}
+        opsUsers={opsUsers}
+        onAssign={handleAssign}
+        onRowClick={(id) => navigate(`/ops/campaigns/${id}`)}
+        isLoading={isLoading}
+        sticky
+        className="mt-6"
+      />
     </OpsLayout>
   );
 }

--- a/src/pages/OpsInbox.jsx
+++ b/src/pages/OpsInbox.jsx
@@ -2,8 +2,7 @@ import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useUser } from '@clerk/clerk-react';
 import OpsLayout from '../layout/OpsLayout';
-import OpsAssignMenu from '../components/OpsAssignMenu.jsx';
-import UserAvatarName from '../components/UserAvatarName.jsx';
+import OpsCampaignTable from '../components/OpsCampaignTable.jsx';
 
 const API_URL = import.meta.env.VITE_API_URL;
 
@@ -166,66 +165,17 @@ export default function OpsInbox() {
     }
   };
 
-  const fmt = (val) => (Array.isArray(val) ? val.join(', ') : val || '-');
-
   return (
     <OpsLayout title="Inbox">
-      {isLoading ? (
-        <div className="py-8 text-center text-sm text-gray-500">Loading...</div>
-      ) : campaigns.length === 0 ? (
-        <div className="py-8 text-center text-sm text-gray-500">No campaigns found.</div>
-      ) : (
-        <div className="mt-8 flow-root overflow-x-auto">
-          <table className="w-full text-left">
-            <thead className="bg-white">
-              <tr>
-                <th className="px-3 py-3.5 text-sm font-semibold text-gray-900">Company</th>
-                <th className="hidden px-3 py-3.5 text-sm font-semibold text-gray-900 sm:table-cell">
-                  Type
-                </th>
-                <th className="hidden px-3 py-3.5 text-sm font-semibold text-gray-900 md:table-cell">
-                  Budget
-                </th>
-                <th className="px-3 py-3.5 text-sm font-semibold text-gray-900">Created By</th>
-                <th className="px-3 py-3.5 text-sm font-semibold text-gray-900">Assigned To</th>
-                <th className="px-3 py-3.5 text-sm font-semibold text-gray-900">Status</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-gray-200">
-              {campaigns.map((c) => (
-                <tr
-                  key={c.id}
-                  onClick={() => navigate(`/ops/campaigns/${c.id}`)}
-                  className="cursor-pointer hover:bg-gray-50"
-                >
-                  <td className="whitespace-nowrap px-3 py-4 text-sm font-medium text-gray-900">
-                    {c.company_name || '-'}
-                  </td>
-                  <td className="hidden whitespace-nowrap px-3 py-4 text-sm text-gray-500 sm:table-cell">
-                    {fmt(c.campaign_type)}
-                  </td>
-                  <td className="hidden whitespace-nowrap px-3 py-4 text-sm text-gray-500 md:table-cell">
-                    {c.ooh_budget_range || '-'}
-                  </td>
-                  <td className="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
-                    {c.created_by ? <UserAvatarName user={c.created_by} size="md" /> : '-'}
-                  </td>
-                  <td className="whitespace-nowrap px-3 py-4 text-sm text-gray-500" onClick={(e) => e.stopPropagation()}>
-                    <OpsAssignMenu
-                      current={c.assigned_to ?? c.ops_user ?? null}
-                      opsUsers={opsUsers}
-                      onSelect={(u) => handleAssign(c.id, u)}
-                    />
-                  </td>
-                  <td className="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
-                    {c.status || '-'}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      )}
+      <OpsCampaignTable
+        title="Inbox"
+        campaigns={campaigns}
+        opsUsers={opsUsers}
+        onAssign={handleAssign}
+        onRowClick={(id) => navigate(`/ops/campaigns/${id}`)}
+        isLoading={isLoading}
+        className="mt-8"
+      />
     </OpsLayout>
   );
 }


### PR DESCRIPTION
## Summary
- add reusable `OpsCampaignTable` component to wrap campaign lists in a styled card
- refactor Ops Home and Ops Inbox to use shared table and consistent layout
- fix assign menu click handling so only the icon prevents navigation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b05980b4b8832e9bf376d39073e61f