### PR TITLE
Update address, unify hover and add Get Started links

### DIFF
--- a/src/components/GetStartedCard.jsx
+++ b/src/components/GetStartedCard.jsx
@@ -13,30 +13,46 @@ const steps = [
     content: 'Fill the New Campaign Form',
     icon: PencilSquareIcon,
     iconBackground: 'bg-[#288dcf]',
+    links: [{ label: 'New Campaign', href: '/campaign/new' }],
   },
   {
     id: 2,
     content: 'Speak to our Experts',
     icon: ChatBubbleLeftRightIcon,
     iconBackground: 'bg-[#288dcf]',
+    links: [
+      {
+        label: 'Chat',
+        href: '#',
+        onClick: () => window.Intercom && window.Intercom('show'),
+      },
+      {
+        label: 'Book a Call',
+        href: 'https://fillout.com/t/kee9zs7Rc3us',
+        external: true,
+      },
+    ],
   },
   {
     id: 3,
     content: 'Make Payment',
     icon: CreditCardIcon,
     iconBackground: 'bg-[#288dcf]',
+    links: [{ label: 'My Campaigns', href: '/campaigns' }],
   },
   {
     id: 4,
     content: 'Upload Creatives or get help in Designing them',
     icon: PhotoIcon,
     iconBackground: 'bg-[#288dcf]',
+    links: [{ label: 'Manage Creatives', href: '/manage-creatives' }],
   },
   {
     id: 5,
     content: 'Track Campaign Goals',
     icon: ChartBarIcon,
     iconBackground: 'bg-[#288dcf]',
+    links: [{ label: 'My Campaigns', href: '/campaigns' }],
   },
 ];
 
@@ -71,8 +87,29 @@ export default function GetStartedCard() {
                         <step.icon className="size-5 text-white" aria-hidden="true" />
                       </span>
                     </div>
-                    <div className="min-w-0 flex-1 pt-1.5">
+                    <div className="min-w-0 flex-1 pt-1.5 flex items-center justify-between">
                       <p className="text-sm text-gray-900">{step.content}</p>
+                      {step.links && (
+                        <div className="flex items-center space-x-4">
+                          {step.links.map(link => (
+                            <a
+                              key={link.label}
+                              href={link.href}
+                              onClick={e => {
+                                if (link.onClick) {
+                                  e.preventDefault();
+                                  link.onClick(e);
+                                }
+                              }}
+                              target={link.external ? '_blank' : undefined}
+                              rel={link.external ? 'noopener noreferrer' : undefined}
+                              className="text-sm font-semibold text-[#288dcf] hover:text-[#1e6fa1]"
+                            >
+                              {link.label}
+                            </a>
+                          ))}
+                        </div>
+                      )}
                     </div>
                   </div>
                 </div>

--- a/src/components/OpsCampaignTable.jsx
+++ b/src/components/OpsCampaignTable.jsx
@@ -67,7 +67,7 @@ export default function OpsCampaignTable({
               <tr
                 key={c.id}
                 onClick={() => onRowClick && onRowClick(c.id)}
-                className="cursor-pointer hover:bg-gray-50"
+                className="group cursor-pointer hover:bg-gray-50"
               >
                 <td className="whitespace-nowrap px-3 py-4 text-sm font-medium text-gray-900">
                   {c.company_name || '-'}
@@ -84,7 +84,7 @@ export default function OpsCampaignTable({
                 <td
                   className={cls(
                     'whitespace-nowrap px-3 py-4 text-sm text-gray-500',
-                    sticky ? 'lg:sticky lg:right-24 lg:bg-white' : ''
+                    sticky ? 'lg:sticky lg:right-24 lg:bg-white lg:group-hover:bg-gray-50' : ''
                   )}
                 >
                   <OpsAssignMenu
@@ -96,7 +96,7 @@ export default function OpsCampaignTable({
                 <td
                   className={cls(
                     'whitespace-nowrap px-3 py-4 text-sm text-gray-500',
-                    sticky ? 'lg:sticky lg:right-0 lg:bg-white' : ''
+                    sticky ? 'lg:sticky lg:right-0 lg:bg-white lg:group-hover:bg-gray-50' : ''
                   )}
                 >
                   {c.status || '-'}

--- a/src/pages/Contact.jsx
+++ b/src/pages/Contact.jsx
@@ -40,9 +40,9 @@ export default function Contact() {
                       <BuildingOffice2Icon aria-hidden="true" className="h-6 w-6 text-gray-400" />
                     </dt>
                     <dd className="text-gray-800">
-                      131 Continental Dr, Suite 305
+                      2261 Market Street STE 85992
                       <br />
-                      Newark, Delaware 19713
+                      San Francisco, CA 94114
                     </dd>
                   </div>
 

--- a/src/pages/PrivacyPolicy.jsx
+++ b/src/pages/PrivacyPolicy.jsx
@@ -104,7 +104,7 @@ export default function PrivacyPolicy() {
           <SectionHeading>Contact</SectionHeading>
           <p>
             <strong>Email:</strong> support@boardbid.ai<br />
-            131 Continental Dr, Suite 305, Newark, New Castle County, Delaware 19713, United States
+            2261 Market Street STE 85992, San Francisco, CA 94114, United States
           </p>
         </div>
       </div>

--- a/src/pages/TermsOfService.jsx
+++ b/src/pages/TermsOfService.jsx
@@ -154,7 +154,7 @@ export default function TermsOfService() {
           <SectionHeading>Contact</SectionHeading>
           <p>
             <strong>Email:</strong> support@boardbid.ai<br />
-            131 Continental Dr, Suite 305, Newark, New Castle County, Delaware 19713, United States
+            2261 Market Street STE 85992, San Francisco, CA 94114, United States
           </p>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- update company address to San Francisco across contact and policy pages
- ensure Ops campaign table hover styling matches inbox
- add helpful links to Get Started checklist

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b065bcf3c4832ea8865082b72d356d