### PR TITLE
Ensure Intercom is always visible and fix BoardBid capitalization

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,6 @@
 import { Routes, Route } from 'react-router-dom';
 import ScrollToTop from './components/ScrollToTop.jsx';
+import Intercom from './components/intercom-landing';
 import Home from './pages/Home';
 import SignInPage from './pages/SignIn';
 import SignUpPage from './pages/SignUp';
@@ -27,6 +28,7 @@ import Pricing from './pages/Pricing';
 function App() {
   return (
     <>
+      <Intercom />
       <ScrollToTop />
       <Routes>
         <Route path="/" element={<Home />} />

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -46,7 +46,7 @@ export default function Footer() {
       <div className="mx-auto max-w-7xl px-6 pb-16 sm:pb-24 lg:px-8 lg:pb-32">
         <div className="border-t border-white/10 pt-12 xl:grid xl:grid-cols-3 xl:gap-8">
           <img
-            alt="Boardbid.ai Logo"
+            alt="BoardBid.ai Logo"
             src="https://ik.imagekit.io/boardbid/BoardBid%20logo-White.avif"
             className="h-8"
           />
@@ -99,7 +99,7 @@ export default function Footer() {
             ))}
           </div>
           <p className="mt-8 text-sm/6 text-gray-400 md:order-1 md:mt-0">
-            &copy; 2025 Boardbid, Inc. All rights reserved.
+            &copy; 2025 BoardBid, Inc. All rights reserved.
           </p>
         </div>
       </div>

--- a/src/components/intercom-landing.jsx
+++ b/src/components/intercom-landing.jsx
@@ -1,16 +1,52 @@
-// components/intercom-landing.js
 import { useEffect } from 'react';
 
-// This component loads the Intercom script.
-// It should not "boot" or "show" the messenger.
+// Loads and boots Intercom so the messenger is available on every page.
 export default function IntercomLoader() {
   useEffect(() => {
-    // Check if the script is already loaded to avoid duplicates
-    if (typeof window !== 'undefined' && !window.Intercom) {
-      // This is the standard Intercom code snippet
-      (function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('reattach_messenger');ic('update',w.intercomSettings);}else{var d=document;var i=function(){i.c(arguments);};i.q=[];i.c=function(args){i.q.push(args);};w.Intercom=i;var l=function(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='https://widget.intercom.io/widget/p1go89tx';var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);};if(document.readyState==='complete'){l();}else if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})();
+    if (typeof window !== 'undefined') {
+      window.intercomSettings = { app_id: 'p1go89tx' };
+
+      if (!window.Intercom) {
+        (function () {
+          var w = window;
+          var ic = w.Intercom;
+          if (typeof ic === 'function') {
+            ic('reattach_messenger');
+            ic('update', w.intercomSettings);
+          } else {
+            var d = document;
+            var i = function () {
+              i.c(arguments);
+            };
+            i.q = [];
+            i.c = function (args) {
+              i.q.push(args);
+            };
+            w.Intercom = i;
+            var l = function () {
+              var s = d.createElement('script');
+              s.type = 'text/javascript';
+              s.async = true;
+              s.src = 'https://widget.intercom.io/widget/p1go89tx';
+              var x = d.getElementsByTagName('script')[0];
+              x.parentNode.insertBefore(s, x);
+            };
+            if (d.readyState === 'complete') {
+              l();
+            } else if (w.attachEvent) {
+              w.attachEvent('onload', l);
+            } else {
+              w.addEventListener('load', l, false);
+            }
+          }
+        })();
+      }
+
+      if (typeof window.Intercom === 'function' && !window.Intercom('booted')) {
+        window.Intercom('boot', window.intercomSettings);
+      }
     }
   }, []);
 
-  return null; // This component does not render any visible UI
+  return null;
 }

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -9,7 +9,6 @@ import Footer from '../components/Footer';
 import FooterCTA from '../components/FooterCTA';
 import MediaFormatsBento from "../components/VenuesSection";
 import { posts } from '../data/blogs';
-import Intercom from '../components/intercom-landing';
 import HomeBanner from '../components/HomeBanner';
 
 export default function Home() {
@@ -25,7 +24,6 @@ export default function Home() {
       <WhyChoose /> 
       <FooterCTA />
       <Footer />
-      <Intercom />
     </>
   );
 }


### PR DESCRIPTION
## Summary
- load and boot Intercom once at app start so the chat widget appears on every page
- remove page-specific Intercom loader and clean up references
- correct Footer branding to consistently use `BoardBid`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b0ac5c47c8832ebecf011f3c36c7d2