### PR TITLE
Add meeting scheduling page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -25,6 +25,7 @@ import OpsCampaignDetail from './pages/OpsCampaignDetail.jsx';
 import ProtectedRoute from './components/ProtectedRoute';
 import OpsProtectedRoute from './components/OpsProtectedRoute.jsx';
 import Pricing from './pages/Pricing';
+import Meet from './pages/Meet';
 
 function App() {
   return (
@@ -51,6 +52,7 @@ function App() {
         <Route path="/terms" element={<TermsOfService />} />
         <Route path="/privacy" element={<PrivacyPolicy />} />
         <Route path="/pricing" element={<Pricing />} />
+        <Route path="/meet" element={<Meet />} />
         <Route path="/ops" element={<OpsProtectedRoute><OpsHome /></OpsProtectedRoute>} />
         <Route path="/ops/inbox" element={<OpsProtectedRoute><OpsInbox /></OpsProtectedRoute>} />
         <Route path="/ops/campaigns/:id/*" element={<OpsProtectedRoute><OpsCampaignDetail /></OpsProtectedRoute>} />

--- a/src/pages/Meet.jsx
+++ b/src/pages/Meet.jsx
@@ -1,0 +1,32 @@
+import { Link } from 'react-router-dom';
+import HeroHeader from '../components/HeroHeader';
+import PricingCTA from '../components/PricingCTA';
+import Footer from '../components/Footer';
+
+export default function Meet() {
+  return (
+    <div className="bg-white pt-24 sm:pt-32">
+      <HeroHeader />
+      <div className="mx-auto max-w-7xl px-6 lg:px-8">
+        <div className="mx-auto w-full max-w-3xl">
+          <iframe
+            src="https://boardbid.fillout.com/book-a-meeting"
+            className="w-full rounded-lg border-0 h-[800px] sm:h-[900px]"
+            title="Book a meeting"
+            loading="lazy"
+          />
+        </div>
+        <div className="mt-8 text-center">
+          <Link
+            to="/"
+            className="text-sm font-semibold text-indigo-600 hover:text-indigo-500"
+          >
+            Know more about us <span aria-hidden="true">→</span>
+          </Link>
+        </div>
+      </div>
+      <PricingCTA />
+      <Footer />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `/meet` route with HeroHeader
- embed Fillout meeting form, link to homepage, pricing CTA and footer

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b998b49550832e848449bbbb022888