### PR TITLE
feat: add meeting page header section

### DIFF
--- a/src/components/SectionHeader.jsx
+++ b/src/components/SectionHeader.jsx
@@ -1,0 +1,10 @@
+export default function SectionHeader({ title, description }) {
+  return (
+    <div className="border-b border-gray-200 pb-5">
+      <h3 className="text-base font-semibold text-gray-900">{title}</h3>
+      {description && (
+        <p className="mt-2 max-w-4xl text-sm text-gray-500">{description}</p>
+      )}
+    </div>
+  );
+}

--- a/src/pages/Meet.jsx
+++ b/src/pages/Meet.jsx
@@ -2,16 +2,20 @@ import { Link } from 'react-router-dom';
 import HeroHeader from '../components/HeroHeader';
 import PricingCTA from '../components/PricingCTA';
 import Footer from '../components/Footer';
+import SectionHeader from '../components/SectionHeader';
 
 export default function Meet() {
   return (
     <div className="bg-white pt-24 sm:pt-32">
       <HeroHeader />
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
-        <p className="mx-auto mb-8 max-w-3xl text-center text-lg leading-8 text-gray-600">
-          Schedule a quick call with our team to explore billboard, airport, transit and other DOOH ad opportunities
-          for your brand.
-        </p>
+        <SectionHeader
+          title="Book a Meeting"
+          description={
+            'Schedule a quick call with our team to explore billboard, airport, transit, and other DOOH ad opportunities. '
+            + 'See how BoardBid.ai can help your brand go live in days.'
+          }
+        />
         <div className="mx-auto w-full max-w-3xl">
           <iframe
             src="https://boardbid.fillout.com/book-a-meeting"


### PR DESCRIPTION
## Summary
- add reusable section header component with optional description
- integrate section header into meeting page with updated copy

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9a420e4d4832e8b2c80d25ee0998c