### PR TITLE
feat: add venue type pages

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -26,6 +26,8 @@ import ProtectedRoute from './components/ProtectedRoute';
 import OpsProtectedRoute from './components/OpsProtectedRoute.jsx';
 import Pricing from './pages/Pricing';
 import Meet from './pages/Meet';
+import VenueTypes from './pages/venues/VenueTypes.jsx';
+import VenueTypeDetail from './pages/venues/VenueTypeDetail.jsx';
 
 function App() {
   return (
@@ -53,6 +55,8 @@ function App() {
         <Route path="/privacy" element={<PrivacyPolicy />} />
         <Route path="/pricing" element={<Pricing />} />
         <Route path="/meet" element={<Meet />} />
+        <Route path="/venue-types" element={<VenueTypes />} />
+        <Route path="/venue-types/:slug" element={<VenueTypeDetail />} />
         <Route path="/ops" element={<OpsProtectedRoute><OpsHome /></OpsProtectedRoute>} />
         <Route path="/ops/inbox" element={<OpsProtectedRoute><OpsInbox /></OpsProtectedRoute>} />
         <Route path="/ops/campaigns/:id/*" element={<OpsProtectedRoute><OpsCampaignDetail /></OpsProtectedRoute>} />

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -56,6 +56,7 @@ export default function Header({ staticHeader = false }) {
       <nav className="space-x-6 text-sm font-semibold text-gray-700">
         <Link to="/blogs" className="hover:text-emerald-600 transition">Blog</Link>
         <Link to="/contact" className="hover:text-emerald-600 transition">Contact</Link>
+        <Link to="/venue-types" className="hover:text-emerald-600 transition">Venue Types</Link>
         <SignedOut>
           <SignInButton mode="modal" afterSignInUrl={withBase('/dashboard')}>
             <button className="hover:text-emerald-600 transition">Login</button>

--- a/src/data/venueTypes.js
+++ b/src/data/venueTypes.js
@@ -1,0 +1,284 @@
+export const venueTypes = [
+  {
+    slug: 'airports',
+    name: 'Airports',
+    image: '',
+    websiteCopy: `Airports are among the most premium advertising environments in the world, offering long dwell times and repeated exposure across a traveler’s journey. From check-in counters and TSA lines to gate concourses, lounges, and baggage claims, airport advertising reaches business professionals, international tourists, and affluent families at moments when they are highly attentive.
+Airports are located in every major U.S. market and international gateway. Large digital walls, interactive kiosks, baggage claim displays, and airline lounge screens each provide multiple touchpoints. The average traveler spends 1–3 hours inside an airport, making it one of the most effective OOH environments for recall.
+Airports are best suited for luxury goods, travel and hospitality, financial services, tech, B2B enterprise, and CPG brands. Examples: a luggage brand dominating baggage claim, a credit card brand in premium lounges, or a ski resort geo-targeting flights leaving Miami. Creative can be dayparted to departure/arrival waves or dynamically updated based on weather and delays.`,
+    videoCopy: `Airports are one of the most effective environments for advertisers. Travelers spend hours inside terminals, lounges, and baggage claims — times when they are focused, aspirational, and open to new ideas. A credit card can promote premium perks, a luxury brand can inspire purchases, or a resort can influence vacation planning before passengers board.
+With BoardBid.ai, you can access airport screens nationwide and align your campaign to terminals, destinations, or times of day. With BoardBid.ai, you can reach this valuable audience of business professionals and affluent travelers at scale. Register at BoardBid.ai today, book a meeting with us, or connect with us live here on our website.`,
+  },
+  {
+    slug: 'bars',
+    name: 'Bars',
+    image: '',
+    websiteCopy: `Bars provide one of the most social, high-energy OOH environments. Digital screens appear in sports bars, pubs, and nightlife venues where people gather to watch games, celebrate, and socialize. Unlike commuting or retail environments, bar audiences are relaxed, engaged, and often posting on social media, amplifying brand impressions beyond the venue.
+Bars exist in urban entertainment districts, college towns, and suburban centers. Dwell times average 90–120 minutes, and many venues align with live events, sports schedules, and weekend peaks.
+This format is ideal for beer, wine, and spirits (where compliant), sports betting and fantasy apps, streaming platforms, QSR and delivery services, telecom, and rideshare. Example: a streaming brand sponsoring Sunday football viewings, a food delivery brand promoting late-night ordering, or a rideshare app reminding guests to get home safely.`,
+    videoCopy: `Bars are powerful advertising environments because they capture people when they’re most social and engaged — watching a championship game, celebrating with friends, or enjoying happy hour. Screens inside bars put your brand right in the middle of the action.
+With BoardBid.ai, you can run campaigns across bar networks nationwide. Imagine a beer brand celebrating every time a team scores, or a rideshare service reminding guests to take a safe ride home. With BoardBid.ai, you can reach this valuable audience in fun, social environments. Register at BoardBid.ai today, book a meeting, or connect with us live on our site.`,
+  },
+  {
+    slug: 'billboards',
+    name: 'Billboards',
+    image: '',
+    websiteCopy: `Billboards are the cornerstone of out-of-home, offering massive reach and brand stature. Static bulletins provide long-term visibility, while digital boards allow advertisers to rotate creatives, daypart, and even react to real-time conditions. Positioned along highways, arterial roads, and urban centers, they deliver impressions at unmatched scale.
+Billboards are in every U.S. market, from rural highways to Times Square. They reach commuters, drivers, tourists, and urban professionals.
+Best-fit advertisers include auto, telecom, QSR, retail, streaming, finance, tourism, and government agencies. Examples: a new QSR franchise announcing its opening, a streaming platform launching a series premiere, or a government campaign promoting safety with “Click It or Ticket.” Digital billboards can dynamically update with traffic, weather, or live scores.`,
+    videoCopy: `Billboards are the most iconic out-of-home format. Whether it’s a massive static face on the interstate or a dynamic screen downtown, billboards dominate attention and build brand credibility.
+With BoardBid.ai, you can buy billboard space from Clear Channel, Outfront, Lamar, and more — all in one place. Run local campaigns or take over a city skyline with a few clicks. With BoardBid.ai, you can reach this valuable audience with scale and flexibility. Register at BoardBid.ai today, book a meeting, or connect with us live on our website.`,
+  },
+  {
+    slug: 'casual-dining',
+    name: 'Casual Dining',
+    image: '',
+    websiteCopy: `Casual dining restaurants are community hubs where families and friends spend time together. Digital screens appear in dining rooms, bar areas, and waiting zones, reaching diners during long dwell times of 45–90 minutes.
+These venues exist across suburbs, small towns, and cities, making them highly scalable for regional or national campaigns. Audiences are family-oriented, with parents, children, and young adults making household decisions.
+Best categories: family entertainment, beverages, QSR, grocery, CPG, retail, and streaming. Examples: a soft drink reinforcing consumption, a family movie promoting a release during kids’ nights, or a theme park running summer promotions.`,
+    videoCopy: `Casual dining venues let you connect with families and groups during relaxed meals. With long dwell times and repeated exposure, your message becomes part of the dining experience.
+With BoardBid.ai, you can advertise across restaurant networks nationwide. From a beverage brand promoting specials to a family movie studio reaching parents at dinner, the opportunities are endless. With BoardBid.ai, you can reach this valuable audience where they gather. Register at BoardBid.ai today, book a meeting, or connect with us live here on our site.`,
+  },
+  {
+    slug: 'convenience-stores',
+    name: 'Convenience Stores',
+    image: '',
+    websiteCopy: `Convenience stores combine in-store displays and fuel pump screens, reaching shoppers during quick trips for gas, snacks, and essentials. Most consumers visit multiple times per week, providing frequency and consistency.
+These venues are located along commuter corridors and neighborhood intersections. Audiences range from professionals grabbing morning coffee to teens buying snacks at night.
+Best-fit advertisers include beverages, energy drinks, snacks, candy, lottery/fintech, automotive fluids, and QSR/delivery services. Examples: morning coffee promos between 6–10am, energy drink ads in afternoons, and QSR tie-ins based on location.`,
+    videoCopy: `Convenience stores influence decisions at the point of purchase. From fueling up on the way to work to grabbing late-night snacks, these screens capture audiences every day.
+With BoardBid.ai, you can run campaigns in convenience store networks across the country. Picture a beverage brand owning the fuel pump in summer, or a fintech company promoting mobile wallet reloads at checkout. With BoardBid.ai, you can reach this valuable audience daily. Register at BoardBid.ai today, book a meeting, or connect with us live on our site.`,
+  },
+  {
+    slug: 'colleges-universities',
+    name: 'Colleges & Universities',
+    image: '',
+    websiteCopy: `Colleges and universities are powerful out-of-home environments that connect with Gen Z consumers at a formative life stage. Screens are located in dining halls, student centers, libraries, gyms, and residence lobbies, ensuring repeated daily exposure.
+Campuses exist across nearly every U.S. state, offering scalable reach for regional or national campaigns. Students are trend-sensitive, tech-savvy, and in the process of forming long-term brand loyalties.
+Best-fit categories include wireless carriers, banking and student credit cards, fashion and footwear, streaming services, gaming, QSR, food delivery, and recruitment campaigns. Examples: an energy drink promoting during finals week, a fashion retailer running back-to-school campaigns, or a streaming service offering student discounts.`,
+    videoCopy: `Colleges and universities connect your brand with Gen Z at a critical stage of life. From dorm lobbies to dining halls, these screens reach students throughout the day.
+With BoardBid.ai, you can run campaigns across campus networks nationwide — whether it’s an energy drink keeping students fueled during exams, or a fashion retailer promoting seasonal styles. With BoardBid.ai, you can reach this valuable audience at scale. Register at BoardBid.ai today, book a meeting, or connect with us live here on our site.`,
+  },
+  {
+    slug: 'dispensaries',
+    name: 'Dispensaries',
+    image: '',
+    websiteCopy: `Dispensaries offer highly targeted reach to age-verified adult consumers in legalized markets. Screens appear in waiting areas, checkout counters, and digital menu boards, reaching consumers in discovery and purchase mindsets.
+Audiences skew 21–44, wellness-focused, lifestyle-oriented, and culturally engaged. They’re open to exploration, making dispensaries ideal for brands that want to connect authentically.
+Best-fit categories: cannabis accessories, CBD, beverages, snacks, lifestyle apparel, music/entertainment, and delivery services. Examples: promoting snack foods during evening peaks, pairing music streaming ads with dispensary visits, or highlighting wellness products at checkout.`,
+    videoCopy: `Dispensaries are unique because consumers are already in discovery mode. They’re browsing, waiting, and open to new ideas — the perfect moment for your brand to connect.
+With BoardBid.ai, you can activate dispensary screens programmatically across legal markets. From snacks and beverages to music and lifestyle, you can reach this valuable audience in one of the fastest-growing retail categories. Register at BoardBid.ai today, book a meeting, or connect with us live here on our website.`,
+  },
+  {
+    slug: 'dmv',
+    name: 'DMVs',
+    image: '',
+    websiteCopy: `Departments of Motor Vehicles (DMVs) are high-dwell environments where residents spend extended wait times. Screens reach a broad cross-section of the population during driver’s license testing, renewals, and registrations.
+Audiences include first-time drivers, parents, older adults, and diverse community members. Wait times often exceed 30 minutes, creating a captive audience for messaging.
+Best categories: auto insurance, driving schools, government safety campaigns, auto dealers, financial services, and civic education. Examples: insurance companies offering quotes during renewals, public safety campaigns like “Don’t Text and Drive,” and local dealerships promoting lease specials.`,
+    videoCopy: `DMVs capture audiences with long wait times and full attention. From new drivers to families, these environments reach a cross-section of your community.
+With BoardBid.ai, you can run DMV campaigns with precision, promoting auto insurance, dealerships, or public safety messages. With BoardBid.ai, you can reach this valuable audience in trusted civic settings. Register at BoardBid.ai today, book a meeting, or connect with us live here on our site.`,
+  },
+  {
+    slug: 'doctors-offices',
+    name: 'Doctor\u2019s Offices',
+    image: '',
+    websiteCopy: `Doctor’s offices reach patients and caregivers in healthcare settings where trust and attention are high. Screens are located in waiting rooms, check-in counters, and exam area corridors.
+Audiences include families, seniors, and health-conscious adults — all focused on wellness. Patients spend significant time in waiting rooms, making this a highly attentive environment.
+Best-fit categories: OTC products, vitamins, health insurance, wellness apps, pharma (where compliant), and lifestyle brands. Examples: allergy medicine during spring, flu campaigns in fall, or supplements during winter. Educational creative performs especially well here.`,
+    videoCopy: `Doctor’s offices deliver trusted, attentive audiences. Patients and caregivers are focused on wellness, making this a perfect time for your message.
+With BoardBid.ai, you can activate doctor’s office screens nationwide. From vitamins and OTC remedies to insurance and wellness apps, you can reach this valuable audience when health is top of mind. Register at BoardBid.ai today, book a meeting, or connect with us live here on our site.`,
+  },
+  {
+    slug: 'gas-stations',
+    name: 'Gas Stations',
+    image: '',
+    websiteCopy: `Gas stations are high-frequency touchpoints where consumers fuel their cars multiple times each week. Screens are positioned at fuel pumps, in-store checkout lines, and forecourt displays, reaching drivers and passengers on the go.
+Audiences are broad, spanning daily commuters, road-trippers, and families. Visits often happen at predictable dayparts — morning commutes, after-work errands, and weekend travel.
+Best-fit categories: beverages, coffee, snacks, automotive fluids, QSR, fintech, and road-trip essentials. Examples: coffee brands owning mornings, energy drinks running in afternoons, and QSR promoting drive-thru offers tied to nearby locations.`,
+    videoCopy: `Gas stations connect your brand to everyday consumers as they fuel up. From morning commuters to weekend road-trippers, these screens deliver repeated, habitual reach.
+With BoardBid.ai, you can target gas station networks nationwide. Imagine a beverage brand dominating mornings or a fintech brand promoting mobile wallet reloads at checkout. With BoardBid.ai, you can reach this valuable audience daily. Register at BoardBid.ai today, book a meeting, or connect with us live here on our website.`,
+  },
+  {
+    slug: 'gyms',
+    name: 'Gyms',
+    image: '',
+    websiteCopy: `Gyms and fitness centers are aspirational advertising environments where audiences are motivated, health-conscious, and actively working on personal goals. Screens are positioned near cardio zones, weight rooms, locker corridors, and studio class areas, ensuring high visibility.
+Gyms are present in nearly every metro and suburban area across the U.S., from national chains to boutique studios. Audiences skew Millennials and Gen Z, with strong representation among professionals and high disposable income households.
+Best-fit categories: athletic apparel, footwear, wearables, nutrition, supplements, fitness apps, wellness brands, health insurance, and lifestyle services. Examples: an athletic brand showcasing new sneakers, a supplement brand pushing recovery products, or a wellness app promoting memberships. Campaigns can daypart around morning and evening peak hours and align with seasonal health goals like New Year resolutions or summer fitness.`,
+    videoCopy: `Gyms reach consumers when they’re focused on health and motivation. Screens in cardio areas, studios, and weight rooms put your brand in front of people in a positive, aspirational mindset.
+With BoardBid.ai, you can launch campaigns across gyms nationwide. From sneakers and supplements to wellness apps and insurance, this is your chance to reach a valuable audience while they’re motivated and receptive. With BoardBid.ai, you can reach this valuable audience at scale. Register at BoardBid.ai today, book a meeting, or connect with us live here on our site.`,
+  },
+  {
+    slug: 'hotels',
+    name: 'Hotels',
+    image: '',
+    websiteCopy: `Hotels provide premium advertising access to leisure and business travelers alike. Screens are positioned in lobbies, elevators, bars, and conference centers, delivering repeated exposure across a guest’s stay.
+Hotels are located in every metro, airport district, and resort destination. They attract a mix of executives, event attendees, tourists, and families. Guests often spend several days on property, increasing message frequency.
+Best-fit categories: travel and tourism, local attractions, dining and nightlife, credit cards, electronics and accessories, premium CPG, and auto rentals. Examples: a credit card brand highlighting travel perks, a tour company promoting same-day excursions, or a local restaurant advertising to visitors in hotel elevators. Campaigns can align with conferences, seasonal tourism, or major city events.`,
+    videoCopy: `Hotels reach travelers at moments of relaxation and exploration. Screens in lobbies, elevators, and conference centers deliver repeated visibility during a guest’s stay.
+With BoardBid.ai, you can target hotels across the U.S. and beyond. Whether you’re a credit card offering travel rewards, a local attraction promoting same-day tickets, or a restaurant driving guests to your door, this is a powerful way to connect. With BoardBid.ai, you can reach this valuable audience of travelers and professionals. Register at BoardBid.ai today, book a meeting, or connect with us live here on our site.`,
+  },
+  {
+    slug: 'liquor-stores',
+    name: 'Liquor Stores',
+    image: '',
+    websiteCopy: `Liquor stores reach shoppers during high-intent purchase moments, as they prepare for social gatherings, celebrations, or personal enjoyment. Screens are located at checkout counters, product displays, and entrance areas.
+These stores exist in every community, with peak traffic around weekends, holidays, and evenings. Audiences are 21+, often shopping for specific occasions, making them highly receptive to upsells and cross-promotions.
+Best-fit categories: spirits, beer, wine (where compliant), mixers, snacks, premium ice, glassware, and rideshare apps. Examples: promoting limited-release whiskey, bundling mixers with vodka, or a rideshare company encouraging safe rides after parties. Campaigns can flight around major holidays like July 4th, Thanksgiving, and New Year’s Eve.`,
+    videoCopy: `Liquor stores connect with consumers preparing for key social moments. Screens at checkout and product displays influence purchases right before they’re made.
+With BoardBid.ai, you can activate liquor store screens across key markets. From promoting limited releases to bundling mixers and snacks, or even reminding shoppers about safe rides home, the opportunities are endless. With BoardBid.ai, you can reach this valuable audience at the point of purchase. Register at BoardBid.ai today, book a meeting, or connect with us live here on our website.`,
+  },
+  {
+    slug: 'malls',
+    name: 'Malls',
+    image: '',
+    websiteCopy: `Malls and lifestyle centers provide direct access to shoppers in browsing and buying mode. Screens appear along concourses, food courts, escalators, and anchor-store entryways, influencing decisions minutes before purchase.
+Malls exist nationwide, from suburban hubs to flagship urban shopping centers. Audiences include families, teens, tourists, and fashion-conscious adults.
+Best-fit categories: fashion, beauty, footwear, electronics, dining, entertainment, and financial services. Examples: a beauty brand promoting seasonal collections, a streaming service launching a series premiere, or a local store announcing a grand opening. Campaigns can align with back-to-school, Black Friday, and holiday gift seasons.`,
+    videoCopy: `Malls are where shoppers discover and buy. Screens in concourses and food courts influence decisions right before checkout.
+With BoardBid.ai, you can run campaigns across mall networks nationwide. Whether it’s fashion, beauty, or entertainment, you can put your brand in front of shoppers minutes before they purchase. With BoardBid.ai, you can reach this valuable audience in high-traffic shopping environments. Register at BoardBid.ai today, book a meeting, or connect with us live here on our site.`,
+  },
+  {
+    slug: 'movie-theaters',
+    name: 'Movie Theaters',
+    image: '',
+    websiteCopy: `Movie theaters provide premium advertising with immersive, distraction-free experiences. Ads run on the big screen before showtime, as well as on lobby and concession displays.
+Theaters are found in every metro and suburban market. Audiences include families, couples, and fans attending blockbuster premieres. Viewers are highly attentive, with no ability to skip ads, making theaters one of the most engaging OOH environments.
+Best-fit categories: entertainment, streaming, gaming, QSR, automotive, telecom, and premium CPG. Examples: aligning campaigns with blockbuster releases, producing branded trailers, or launching interactive lobby displays. Campaigns often peak during summer movie season and holiday weekends.`,
+    videoCopy: `Movie theaters give you an audience that’s focused and fully engaged. From pre-show big-screen ads to lobby displays, your brand is showcased in a premium, immersive way.
+With BoardBid.ai, you can activate campaigns across theaters nationwide. From entertainment and gaming to QSR and automotive, your brand gets the spotlight it deserves. With BoardBid.ai, you can reach this valuable audience in distraction-free environments. Register at BoardBid.ai today, book a meeting, or connect with us live here on our site.`,
+  },
+  {
+    slug: 'office-buildings',
+    name: 'Office Buildings',
+    image: '',
+    websiteCopy: `Office buildings and corporate towers provide advertisers with consistent, high-value exposure to professional audiences. Screens are located in lobbies, elevators, break areas, and parking garages, ensuring repeated visibility throughout the workday.
+These venues exist in every major metro and suburban office park. Audiences include executives, professionals, decision-makers, and office staff — people who directly influence B2B and consumer purchase decisions.
+Best-fit categories: B2B software, IT solutions, financial services, insurance, consulting, executive education, luxury goods, and premium travel. Examples: a SaaS company promoting enterprise solutions, a fintech brand advertising retirement products, or a luxury carmaker connecting with high-earning professionals. Campaigns can align with work hours, conferences, or urban commuting schedules.`,
+    videoCopy: `Office buildings put your brand in front of decision-makers all day long. From lobbies to elevators, your message gets repeated exposure among professionals and executives.
+With BoardBid.ai, you can target Class A office towers nationwide. Whether you’re a B2B software provider, a financial services brand, or a luxury retailer, you can reach this valuable audience in trusted business environments. Register at BoardBid.ai today, book a meeting, or connect with us live here on our website.`,
+  },
+  {
+    slug: 'pharmacies',
+    name: 'Pharmacies',
+    image: '',
+    websiteCopy: `Pharmacies are trusted community touchpoints where consumers shop for health, wellness, and everyday essentials. Screens are located in waiting areas, checkout aisles, and product displays, delivering influence at the point of purchase.
+Pharmacies exist in every neighborhood, often co-located with grocery and convenience. Audiences include seniors, caregivers, families, and wellness-focused adults.
+Best-fit categories: OTC remedies, vitamins and supplements, insurance, health apps, diagnostics, CPG, and seasonal wellness products. Examples: flu medicine in fall, allergy campaigns in spring, vitamin bundles in winter, or wellness apps offering sign-up QR codes.`,
+    videoCopy: `Pharmacies connect your brand with wellness-minded consumers at trusted moments of decision. Screens at checkout and in aisles influence shoppers as they choose products.
+With BoardBid.ai, you can activate campaigns in pharmacy networks nationwide. From vitamins and flu remedies to insurance and healthy snacks, you can reach this valuable audience in trusted retail settings. Register at BoardBid.ai today, book a meeting, or connect with us live here on our site.`,
+  },
+  {
+    slug: 'qsr',
+    name: 'QSR',
+    image: '',
+    websiteCopy: `Quick service restaurants (QSR) deliver high-frequency reach, as consumers visit for breakfast, lunch, dinner, and snacks. Screens are located at order counters, dining rooms, and drive-thru lanes, ensuring multiple touchpoints.
+QSRs exist in every community — from urban centers to small towns. Audiences include families, students, workers, and commuters who are habitual visitors.
+Best-fit categories: beverages, snacks, food delivery, entertainment, financial apps, mobile wallets, and local retail. Examples: a beverage brand tying promotions to mealtimes, a delivery app advertising dinner offers, or a mobile wallet encouraging contactless pay.`,
+    videoCopy: `Quick service restaurants give you repeated exposure across breakfast, lunch, and dinner. Screens at counters and drive-thrus connect with habitual customers every day.
+With BoardBid.ai, you can activate campaigns across national QSR networks. Whether you’re a beverage brand, an entertainment company, or a fintech app, you can reach this valuable audience at scale. Register at BoardBid.ai today, book a meeting, or connect with us live here on our website.`,
+  },
+  {
+    slug: 'recreational-locations',
+    name: 'Recreational Locations',
+    image: '',
+    websiteCopy: `Recreational venues include bowling alleys, skating rinks, arcades, trampoline parks, golf simulators, and family entertainment centers. Screens are placed in lobbies, play areas, and concession zones, reaching audiences while they relax and have fun.
+These venues exist nationwide, particularly in suburban and family-oriented communities. Audiences include families, teens, and young adults enjoying leisure activities.
+Best-fit categories: snacks, beverages, entertainment, gaming, apparel, local attractions, and education/enrichment brands. Examples: a gaming console brand promoting during arcades, a local theme park targeting families at bowling alleys, or a beverage brand tying into weekend recreation.`,
+    videoCopy: `Recreational venues connect your brand with families and young adults in playful, social environments. From bowling alleys to arcades, these are audiences enjoying downtime and ready for new experiences.
+With BoardBid.ai, you can run campaigns across recreational networks nationwide. From snacks and beverages to gaming and entertainment, you can reach this valuable audience where they play. Register at BoardBid.ai today, book a meeting, or connect with us live here on our site.`,
+  },
+  {
+    slug: 'retail',
+    name: 'Retail',
+    image: '',
+    websiteCopy: `Retail environments include big-box stores, specialty shops, home improvement centers, electronics stores, and department stores. Screens are positioned in aisles, concourses, and checkout counters, delivering influence at the point of purchase.
+Retail networks cover every major U.S. market. Audiences include families, shoppers, students, and professionals across income levels, often in buying mode.
+Best-fit categories: electronics, appliances, fashion, beauty, smart home products, financial services, loyalty programs, and CPG. Examples: a fashion brand promoting seasonal styles, an electronics company showcasing new releases, or a financial service driving loyalty card sign-ups.`,
+    videoCopy: `Retail puts your brand directly in front of shoppers as they browse and buy. From electronics and fashion to beauty and financial services, these screens influence purchases in real time.
+With BoardBid.ai, you can activate campaigns across retail networks nationwide. With BoardBid.ai, you can reach this valuable audience at the point of sale. Register at BoardBid.ai today, book a meeting, or connect with us live here on our site.`,
+  },
+  {
+    slug: 'salons',
+    name: 'Salons',
+    image: '',
+    websiteCopy: `Salons and barbershops are highly attentive advertising environments where clients spend 45–120 minutes during services. Screens are placed in waiting areas, mirrors, and styling stations, ensuring repeated exposure while customers are engaged and relaxed.
+Salons exist in every neighborhood — from upscale urban studios to suburban barbershops — and reach style-conscious consumers who trust professional recommendations. Dwell times are long, making salons ideal for messaging that benefits from repeated impressions.
+Best-fit categories: beauty and skincare, haircare, fashion, wellness apps, luxury products, credit cards, and local retail. Examples: a beauty brand showcasing seasonal looks, a subscription service offering automatic product refills, or a fashion retailer driving traffic to nearby stores.`,
+    videoCopy: `Salons offer a premium way to connect with style-conscious consumers. Long appointments mean your brand message is seen multiple times, in trusted, attentive environments.
+With BoardBid.ai, you can activate campaigns across salon networks nationwide. From beauty and fashion to wellness and lifestyle brands, you can reach this valuable audience when they’re most engaged. Register at BoardBid.ai today, book a meeting, or connect with us live here on our site.`,
+  },
+  {
+    slug: 'schools',
+    name: 'Schools',
+    image: '',
+    websiteCopy: `School advertising networks include common areas, entryways, athletic facilities, and hallways in public and private schools. They connect with students, parents, teachers, and staff in trusted local community settings.
+Schools exist in suburban and urban neighborhoods across the U.S., often serving as central community hubs. Audiences include parents making family decisions, educators, and students participating in extracurricular programs.
+Best-fit categories: tutoring, after-school enrichment, family entertainment, local retail, safety programs, and health/wellness services. Examples: a tutoring company promoting enrollment before school terms, a local family fun center advertising weekend specials, or a safety campaign reinforcing community awareness.`,
+    videoCopy: `Schools connect your message directly to families and communities. Screens in entryways and athletic facilities make your brand visible to parents, students, and staff.
+With BoardBid.ai, you can reach schools across the U.S. to promote tutoring, local retail, or enrichment programs. With BoardBid.ai, you can reach this valuable audience in trusted educational environments. Register at BoardBid.ai today, book a meeting, or connect with us live here on our site.`,
+  },
+  {
+    slug: 'sports-entertainment',
+    name: 'Sports Entertainment',
+    image: '',
+    websiteCopy: `Sports venues — from professional stadiums and arenas to local sports bars — capture fans at their peak excitement. Screens are located in concourses, suites, food courts, and viewing zones, delivering high-energy impressions.
+These venues exist in every major market and align with tentpole sporting events like NFL, NBA, MLB, NHL, and NCAA seasons. Audiences are passionate, engaged, and ready to celebrate with brands that become part of the action.
+Best-fit categories: beer/spirits (where compliant), sports betting and fantasy, QSR, automotive, telco, entertainment, and retail. Examples: a beer brand running “cheers” creative during scoring moments, a betting app promoting same-day odds, or an auto brand showcasing during halftime.`,
+    videoCopy: `Sports environments deliver unmatched passion and focus. From stadium concourses to sports bars on game day, your brand becomes part of the excitement.
+With BoardBid.ai, you can run campaigns across sports entertainment venues nationwide. Whether you’re promoting beer, betting, food, or cars, this is a chance to connect with fans in unforgettable moments. With BoardBid.ai, you can reach this valuable audience when the energy is highest. Register at BoardBid.ai today, book a meeting, or connect with us live here on our site.`,
+  },
+  {
+    slug: 'street-furniture',
+    name: 'Street Furniture',
+    image: '',
+    websiteCopy: `Street furniture includes bus shelters, kiosks, transit benches, and newsstands — providing high-frequency, street-level visibility in urban and suburban corridors. Positioned along sidewalks and commuter routes, these placements deliver repeated impressions to pedestrians, transit riders, and drivers.
+Street furniture is present in nearly every metro and neighborhood, making it scalable for both national and local campaigns.
+Best-fit categories: mobile apps, telco, QSR, retail, entertainment, streaming, and civic campaigns. Examples: a food delivery app running location-based ads, a telco brand promoting new plans, or a city tourism board welcoming visitors.`,
+    videoCopy: `Street furniture puts your brand at eye level in high-traffic pedestrian zones. From bus shelters to kiosks, these screens are visible all day long to commuters and shoppers.
+With BoardBid.ai, you can activate street furniture campaigns in cities nationwide. From mobile apps to QSR, retail, and streaming, you can reach this valuable audience where they live and work. Register at BoardBid.ai today, book a meeting, or connect with us live here on our site.`,
+  },
+  {
+    slug: 'taxis-rideshares',
+    name: 'Taxis & Rideshares',
+    image: '',
+    websiteCopy: `Taxi and rideshare advertising combines interior screens with digital rooftop signage, delivering both one-to-one engagement and citywide impressions. Interior tablets target riders during trips, while rooftop units reach urban pedestrians and drivers.
+These formats are concentrated in urban cores, airports, nightlife districts, and event zones, making them ideal for tourism and citywide branding. Audiences include business travelers, tourists, and urban residents.
+Best-fit categories: entertainment, streaming, fintech, travel, dining, local attractions, and delivery services. Examples: a rideshare app promoting itself on competitor vehicles, a streaming brand entertaining passengers, or a restaurant driving foot traffic after nightlife events.`,
+    videoCopy: `Taxis and rideshares deliver your brand to audiences in motion. Inside vehicles, riders engage directly with interactive content, while rooftop signage makes your message part of the city skyline.
+With BoardBid.ai, you can activate rideshare and taxi campaigns in major metros. From entertainment and fintech to tourism and dining, this is a chance to reach valuable audiences on the move. With BoardBid.ai, you can reach this valuable audience across cities nationwide. Register at BoardBid.ai today, book a meeting, or connect with us live here on our site.`,
+  },
+  {
+    slug: 'transit-stations',
+    name: 'Transit Stations',
+    image: '',
+    websiteCopy: `Transit stations — including subways, commuter rail hubs, and bus terminals — capture audiences during dwell times while waiting for transportation. Screens are positioned on platforms, concourses, and entry/exit points, delivering multiple impressions as commuters move through the space.
+Transit stations are concentrated in every major metro, reaching millions of daily riders. Audiences include urban professionals, students, blue-collar workers, and tourists. The frequency of commuting ensures repeated exposure, often five days per week.
+Best-fit categories: banking, telco, government services, retail, entertainment, and QSR. Examples: a bank promoting contactless payments, a telco launching new data plans, or a QSR driving lunch traffic with nearby offers. Campaigns can align with rush-hour peaks and major city events.`,
+    videoCopy: `Transit stations deliver repeated exposure to commuters every day. Screens on platforms and concourses keep your brand front and center during long dwell times.
+With BoardBid.ai, you can run campaigns across transit stations in major cities nationwide. From banking and telco to retail and QSR, you can reach this valuable audience with unmatched frequency. Register at BoardBid.ai today, book a meeting, or connect with us live here on our website.`,
+  },
+  {
+    slug: 'urban-panels',
+    name: 'Urban Panels',
+    image: '',
+    websiteCopy: `Urban panels are street-level displays built into kiosks, bus shelters, and city infrastructure. Positioned at eye level in high-density pedestrian and vehicular zones, they deliver constant impressions in neighborhoods where people live, shop, and work.
+These panels are prominent in metro areas, often clustered in retail corridors, transit-heavy streets, and entertainment districts. They are designed for repeated exposure, delivering frequency and consistency for both national and local campaigns.
+Best-fit categories: fashion, beauty, telco, mobile apps, entertainment, QSR, and tourism. Examples: a fashion retailer showcasing seasonal looks, a telco advertising unlimited plans, or a city tourism board welcoming visitors downtown.`,
+    videoCopy: `Urban panels deliver visibility where people walk, shop, and commute. Positioned at eye level, they ensure your brand gets repeated exposure all day long.
+With BoardBid.ai, you can activate campaigns on urban panels across cities nationwide. From fashion and beauty to QSR and tourism, you can reach this valuable audience in the heart of the city. Register at BoardBid.ai today, book a meeting, or connect with us live here on our website.`,
+  },
+  {
+    slug: 'veterinary-offices',
+    name: 'Veterinary Offices',
+    image: '',
+    websiteCopy: `Veterinary offices are trusted community environments where pet owners spend extended time waiting for appointments. Screens in lobbies, exam rooms, and checkout counters connect with engaged, pet-focused households.
+These venues exist in every suburb and urban neighborhood. Audiences include families and individuals who spend above average on pets, often considering them part of the family.
+Best-fit categories: pet food and treats, pet insurance, grooming and boarding, veterinary products, automotive (pet-safe travel), and cleaning supplies. Examples: a premium pet food brand advertising subscription deliveries, an insurance company promoting coverage plans, or a grooming service showcasing seasonal specials.`,
+    videoCopy: `Veterinary offices let you connect with devoted pet owners while they wait for appointments. These are engaged households who love their pets and spend generously on their care.
+With BoardBid.ai, you can run campaigns in veterinary offices nationwide. From pet food and insurance to grooming and wellness products, you can reach this valuable audience in trusted care settings. Register at BoardBid.ai today, book a meeting, or connect with us live here on our site.`,
+  },
+];
+
+export default venueTypes;

--- a/src/pages/venues/VenueTypeDetail.jsx
+++ b/src/pages/venues/VenueTypeDetail.jsx
@@ -1,0 +1,32 @@
+import { useParams } from 'react-router-dom';
+import PageHeader from '../../components/PageHeader.jsx';
+import { venueTypes } from '../../data/venueTypes.js';
+
+export default function VenueTypeDetail() {
+  const { slug } = useParams();
+  const venue = venueTypes.find((v) => v.slug === slug);
+
+  if (!venue) {
+    return (
+      <div className="mx-auto max-w-7xl px-6 py-24">
+        <PageHeader title="Venue Not Found" align="center" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl px-6 py-24">
+      <PageHeader title={venue.name} align="center" />
+      {venue.image && (
+        <img src={venue.image} alt={venue.name} className="mb-10 w-full rounded-lg object-cover" />
+      )}
+      <div className="space-y-8">
+        <p className="whitespace-pre-line">{venue.websiteCopy}</p>
+        <div>
+          <h2 className="text-xl font-semibold">Video Copy</h2>
+          <p className="mt-2 whitespace-pre-line">{venue.videoCopy}</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/venues/VenueTypes.jsx
+++ b/src/pages/venues/VenueTypes.jsx
@@ -1,0 +1,27 @@
+import { Link } from 'react-router-dom';
+import PageHeader from '../../components/PageHeader.jsx';
+import { venueTypes } from '../../data/venueTypes.js';
+
+export default function VenueTypes() {
+  return (
+    <div className="mx-auto max-w-7xl px-6 py-24">
+      <PageHeader title="Venue Types" subtitle="Explore advertising environments" align="center" />
+      <div className="mt-10 grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
+        {venueTypes.map((v) => (
+          <Link
+            key={v.slug}
+            to={`/venue-types/${v.slug}`}
+            className="block overflow-hidden rounded-lg bg-white shadow hover:shadow-md transition-shadow"
+          >
+            {v.image && (
+              <img src={v.image} alt={v.name} className="h-48 w-full object-cover" />
+            )}
+            <div className="p-6">
+              <h3 className="text-lg font-semibold text-gray-900">{v.name}</h3>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- link Venue Types from header for quick access
- add grid list of all venue types and dynamic detail pages
- define venue copy in a centralized data file for customization

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bdc6ef68b4832ea7776f611245233d