### PR TITLE
feat: redesign venue types grid with icons

### DIFF
--- a/src/pages/venues/VenueTypes.jsx
+++ b/src/pages/venues/VenueTypes.jsx
@@ -1,28 +1,104 @@
-import { Link } from 'react-router-dom';
-import PageHeader from '../../components/PageHeader.jsx';
-import { venueTypes } from '../../data/venueTypes.js';
+import { Link } from "react-router-dom";
+import PageHeader from "../../components/PageHeader.jsx";
+import Card from "../../components/Card.jsx";
+import { venueTypes, VENUE_PLACEHOLDER_IMG } from "../../data/venueTypes.js";
+
+// ✅ Only icons that exist in @heroicons/react/24/outline
+import {
+  PaperAirplaneIcon,      // airports
+  BuildingStorefrontIcon, // retail-like, c-stores, liquor, street furniture
+  BuildingOffice2Icon,    // offices, hotels
+  AcademicCapIcon,        // colleges, schools
+  IdentificationIcon,     // DMV
+  HeartIcon,              // doctors, pharmacies, vets
+  TruckIcon,              // gas stations, taxis/rideshares
+  UserGroupIcon,          // bars, casual dining
+  ShoppingBagIcon,        // malls, retail
+  FilmIcon,               // movie theaters
+  TrophyIcon,             // sports & rec
+  RectangleStackIcon,     // billboards / urban panels
+  MapIcon,                // transit stations
+  RocketLaunchIcon,       // QSR (playful/fast)
+  SparklesIcon,           // salons / dispensaries
+  BoltIcon,               // gyms
+  Squares2X2Icon,         // fallback
+} from "@heroicons/react/24/outline";
+
+// Map venue slugs to icons
+const iconMap = {
+  airports: PaperAirplaneIcon,
+  bars: UserGroupIcon,
+  billboards: RectangleStackIcon,
+  "casual-dining": UserGroupIcon,
+  "convenience-stores": BuildingStorefrontIcon,
+  "colleges-universities": AcademicCapIcon,
+  dispensaries: SparklesIcon,
+  dmv: IdentificationIcon,
+  "doctors-offices": HeartIcon,
+  "gas-stations": TruckIcon,
+  gyms: BoltIcon,
+  hotels: BuildingOffice2Icon,
+  "liquor-stores": BuildingStorefrontIcon,
+  malls: ShoppingBagIcon,
+  "movie-theaters": FilmIcon,
+  "office-buildings": BuildingOffice2Icon,
+  pharmacies: HeartIcon,
+  qsr: RocketLaunchIcon,
+  "recreational-locations": TrophyIcon,
+  retail: BuildingStorefrontIcon,
+  salons: SparklesIcon,
+  schools: AcademicCapIcon,
+  "sports-entertainment": TrophyIcon,
+  "street-furniture": RectangleStackIcon,
+  "taxis-rideshares": TruckIcon,
+  "transit-stations": MapIcon,
+  "urban-panels": RectangleStackIcon,
+  "veterinary-offices": HeartIcon,
+};
 
 export default function VenueTypes() {
   return (
-    <div className="mx-auto max-w-4xl px-6 py-24">
+    <div className="mx-auto max-w-7xl px-6 py-24">
       <PageHeader
         title="Venue Types"
-        subtitle="Explore available formats"
+        subtitle="Explore advertising environments"
         align="center"
       />
-      <ul className="mt-10 divide-y divide-gray-200 rounded-xl bg-white shadow-sm ring-1 ring-gray-200/60">
-        {venueTypes.map((v) => (
-          <li key={v.slug} className="flex justify-between items-center px-4 py-5 sm:px-6">
-            <span className="text-sm font-medium text-gray-900">{v.name}</span>
-            <Link
-              to={`/venue-types/${v.slug}`}
-              className="text-sm font-semibold text-indigo-600 hover:text-indigo-500"
-            >
-              Learn more &rarr;
+
+      <div className="mt-14 grid grid-cols-1 gap-10 sm:grid-cols-2 lg:grid-cols-3">
+        {venueTypes.map((v) => {
+          const Icon = iconMap[v.slug] || Squares2X2Icon;
+          const imgSrc =
+            v.image && v.image.trim() !== "" ? v.image : VENUE_PLACEHOLDER_IMG;
+
+          return (
+            <Link key={v.slug} to={`/venue-types/${v.slug}`} className="group block">
+              <Card className="hover:shadow-xl hover:ring-gray-300 transition-all duration-300">
+                {/* Image (with placeholder) */}
+                <div className="relative h-48 w-full overflow-hidden rounded-md">
+                  <img
+                    src={imgSrc}
+                    alt={v.name}
+                    className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
+                  />
+                  <div className="absolute inset-0 bg-gradient-to-t from-black/30 via-black/5 to-transparent opacity-70 group-hover:opacity-60 transition-opacity" />
+                </div>
+
+                {/* Title + Icon */}
+                <div className="mt-4 flex items-center justify-between">
+                  <h3 className="text-lg font-semibold text-gray-900 group-hover:text-[#288dcf] transition-colors">
+                    {v.name}
+                  </h3>
+                  <span className="ml-3 inline-flex h-9 w-9 items-center justify-center rounded-full bg-gray-100 ring-1 ring-gray-200 text-gray-600 group-hover:bg-[#288dcf] group-hover:text-white group-hover:ring-[#288dcf] transition-colors">
+                    <Icon className="h-5 w-5" aria-hidden="true" />
+                  </span>
+                </div>
+              </Card>
             </Link>
-          </li>
-        ))}
-      </ul>
+          );
+        })}
+      </div>
     </div>
   );
 }
+


### PR DESCRIPTION
## Summary
- redesign venue types page into a card-based grid with heroicons
- add image fallback using placeholder constant

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bdd8d74c20832ea03dff6513d1b49d