### PR TITLE
Add marketing elements to venue pages

### DIFF
--- a/src/pages/venues/VenueTypeDetail.jsx
+++ b/src/pages/venues/VenueTypeDetail.jsx
@@ -1,6 +1,10 @@
 import { useParams } from "react-router-dom";
 import PageHeader from "../../components/PageHeader.jsx";
 import Card from "../../components/Card.jsx";
+import HeroHeader from "../../components/HeroHeader.jsx";
+import HomeBanner from "../../components/HomeBanner.jsx";
+import PricingCTA from "../../components/PricingCTA.jsx";
+import Footer from "../../components/Footer.jsx";
 import YouTubePlayer from "../../components/YouTubePlayer.jsx";
 import {
   PlayIcon,
@@ -84,99 +88,105 @@ export default function VenueTypeDetail() {
   const { slug } = useParams();
   const venue = venueTypes.find((v) => v.slug === slug);
 
-  if (!venue) {
-    return (
-      <div className="mx-auto max-w-7xl px-6 py-24">
-        <PageHeader title="Venue Not Found" align="center" />
-      </div>
-    );
-  }
-
   const imgSrc =
-    venue.image && venue.image.trim() !== "" ? venue.image : VENUE_PLACEHOLDER_IMG;
+    venue?.image && venue.image.trim() !== "" ? venue.image : VENUE_PLACEHOLDER_IMG;
 
   return (
-    <div className="mx-auto max-w-4xl px-6 py-24">
-      <PageHeader
-        title={venue.name}
-        subtitle="Format overview, highlights & strategy"
-        align="center"
-      />
+    <div className="bg-white pt-24 sm:pt-32">
+      <HeroHeader />
+      <HomeBanner />
 
-      {/* Hero Image */}
-      <Card className="mt-10">
-        <div className="relative h-64 w-full overflow-hidden rounded-lg">
-          <img src={imgSrc} alt={venue.name} className="h-full w-full object-cover" />
-          <div className="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/30 via-black/10 to-transparent" />
-        </div>
-      </Card>
+      {venue ? (
+        <div className="mx-auto max-w-4xl px-6 py-24">
+          <PageHeader
+            title={venue.name}
+            subtitle="Format overview, highlights & strategy"
+            align="center"
+          />
 
-      {/* Highlights */}
-      {venue.highlights?.length > 0 && (
-        <Card className="mt-8">
-          <h2 className="mb-4 text-xl font-semibold text-gray-900">Highlights</h2>
-          <ul className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-            {venue.highlights.map((h, i) => {
-              const Icon = iconMap[h.icon] || SparklesIcon;
-              return (
-                <li key={i} className="flex items-start gap-3">
-                  <Icon className="mt-0.5 h-5 w-5 text-[#288dcf]" />
-                  <p className="text-sm text-gray-700">{h.text}</p>
-                </li>
-              );
-            })}
-          </ul>
-        </Card>
-      )}
-
-      {/* Strategy Playbook */}
-      {venue.strategy?.length > 0 && (
-        <Card className="mt-8">
-          <h2 className="mb-4 text-xl font-semibold text-gray-900">Strategy Playbook</h2>
-          <ul className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-            {venue.strategy.map((s, i) => {
-              const Icon = iconMap[s.icon] || PresentationChartBarIcon;
-              return (
-                <li key={i} className="flex items-start gap-3">
-                  <Icon className="mt-0.5 h-5 w-5 text-[#288dcf]" />
-                  <p className="text-sm text-gray-700">{s.text}</p>
-                </li>
-              );
-            })}
-          </ul>
-        </Card>
-      )}
-
-      {/* Overview */}
-      <Card className="mt-8">
-        <h2 className="mb-2 text-xl font-semibold text-gray-900">Overview</h2>
-        <p className="whitespace-pre-line leading-7 text-gray-700">{venue.websiteCopy}</p>
-      </Card>
-
-      {/* Video Section */}
-      <Card className="mt-8">
-        <h2 className="mb-4 text-xl font-semibold text-gray-900">Video</h2>
-        {venue.youtubeId ? (
-          <div className="mb-6">
-            <YouTubePlayer videoId={venue.youtubeId} title={`${venue.name} — Video`} />
-          </div>
-        ) : (
-          <div className="mb-6 relative overflow-hidden rounded-lg ring-1 ring-gray-200/60">
-            <img
-              src={VENUE_VIDEO_PLACEHOLDER_THUMB}
-              alt="Video placeholder"
-              className="h-56 w-full object-cover"
-            />
-            <div className="absolute inset-0 flex items-center justify-center bg-black/30">
-              <div className="flex items-center gap-3 rounded-full bg-white/90 px-4 py-2 shadow">
-                <PlayIcon className="h-5 w-5 text-[#288dcf]" />
-                <span className="text-sm font-medium text-gray-800">Video coming soon</span>
-              </div>
+          {/* Hero Image */}
+          <Card className="mt-10">
+            <div className="relative h-64 w-full overflow-hidden rounded-lg">
+              <img src={imgSrc} alt={venue.name} className="h-full w-full object-cover" />
+              <div className="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/30 via-black/10 to-transparent" />
             </div>
-          </div>
-        )}
-        <p className="mt-2 whitespace-pre-line leading-7 text-gray-700">{venue.videoCopy}</p>
-      </Card>
+          </Card>
+
+          {/* Highlights */}
+          {venue.highlights?.length > 0 && (
+            <Card className="mt-8">
+              <h2 className="mb-4 text-xl font-semibold text-gray-900">Highlights</h2>
+              <ul className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                {venue.highlights.map((h, i) => {
+                  const Icon = iconMap[h.icon] || SparklesIcon;
+                  return (
+                    <li key={i} className="flex items-start gap-3">
+                      <Icon className="mt-0.5 h-5 w-5 text-[#288dcf]" />
+                      <p className="text-sm text-gray-700">{h.text}</p>
+                    </li>
+                  );
+                })}
+              </ul>
+            </Card>
+          )}
+
+          {/* Strategy Playbook */}
+          {venue.strategy?.length > 0 && (
+            <Card className="mt-8">
+              <h2 className="mb-4 text-xl font-semibold text-gray-900">Strategy Playbook</h2>
+              <ul className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                {venue.strategy.map((s, i) => {
+                  const Icon = iconMap[s.icon] || PresentationChartBarIcon;
+                  return (
+                    <li key={i} className="flex items-start gap-3">
+                      <Icon className="mt-0.5 h-5 w-5 text-[#288dcf]" />
+                      <p className="text-sm text-gray-700">{s.text}</p>
+                    </li>
+                  );
+                })}
+              </ul>
+            </Card>
+          )}
+
+          {/* Overview */}
+          <Card className="mt-8">
+            <h2 className="mb-2 text-xl font-semibold text-gray-900">Overview</h2>
+            <p className="whitespace-pre-line leading-7 text-gray-700">{venue.websiteCopy}</p>
+          </Card>
+
+          {/* Video Section */}
+          <Card className="mt-8">
+            <h2 className="mb-4 text-xl font-semibold text-gray-900">Video</h2>
+            {venue.youtubeId ? (
+              <div className="mb-6">
+                <YouTubePlayer videoId={venue.youtubeId} title={`${venue.name} — Video`} />
+              </div>
+            ) : (
+              <div className="mb-6 relative overflow-hidden rounded-lg ring-1 ring-gray-200/60">
+                <img
+                  src={VENUE_VIDEO_PLACEHOLDER_THUMB}
+                  alt="Video placeholder"
+                  className="h-56 w-full object-cover"
+                />
+                <div className="absolute inset-0 flex items-center justify-center bg-black/30">
+                  <div className="flex items-center gap-3 rounded-full bg-white/90 px-4 py-2 shadow">
+                    <PlayIcon className="h-5 w-5 text-[#288dcf]" />
+                    <span className="text-sm font-medium text-gray-800">Video coming soon</span>
+                  </div>
+                </div>
+              </div>
+            )}
+            <p className="mt-2 whitespace-pre-line leading-7 text-gray-700">{venue.videoCopy}</p>
+          </Card>
+        </div>
+      ) : (
+        <div className="mx-auto max-w-7xl px-6 py-24">
+          <PageHeader title="Venue Not Found" align="center" />
+        </div>
+      )}
+
+      <PricingCTA />
+      <Footer />
     </div>
   );
 }

--- a/src/pages/venues/VenueTypes.jsx
+++ b/src/pages/venues/VenueTypes.jsx
@@ -1,6 +1,10 @@
 import { Link } from "react-router-dom";
 import PageHeader from "../../components/PageHeader.jsx";
 import Card from "../../components/Card.jsx";
+import HeroHeader from "../../components/HeroHeader.jsx";
+import HomeBanner from "../../components/HomeBanner.jsx";
+import PricingCTA from "../../components/PricingCTA.jsx";
+import Footer from "../../components/Footer.jsx";
 import { venueTypes, VENUE_PLACEHOLDER_IMG } from "../../data/venueTypes.js";
 
 // ✅ Only icons that exist in @heroicons/react/24/outline
@@ -58,46 +62,58 @@ const iconMap = {
 
 export default function VenueTypes() {
   return (
-    <div className="mx-auto max-w-7xl px-6 py-24">
-      <PageHeader
-        title="Venue Types"
-        subtitle="Explore advertising environments"
-        align="center"
-      />
+    <div className="bg-white pt-24 sm:pt-32">
+      <HeroHeader />
+      <HomeBanner />
 
-      <div className="mt-14 grid grid-cols-1 gap-10 sm:grid-cols-2 lg:grid-cols-3">
-        {venueTypes.map((v) => {
-          const Icon = iconMap[v.slug] || Squares2X2Icon;
-          const imgSrc =
-            v.image && v.image.trim() !== "" ? v.image : VENUE_PLACEHOLDER_IMG;
+      <div className="mx-auto max-w-7xl px-6 py-24">
+        <PageHeader
+          title="Venue Types"
+          subtitle="Explore advertising environments"
+          align="center"
+        />
 
-          return (
-            <Link key={v.slug} to={`/venue-types/${v.slug}`} className="group block">
-              <Card className="hover:shadow-xl hover:ring-gray-300 transition-all duration-300">
-                {/* Image (with placeholder) */}
-                <div className="relative h-48 w-full overflow-hidden rounded-md">
-                  <img
-                    src={imgSrc}
-                    alt={v.name}
-                    className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
-                  />
-                  <div className="absolute inset-0 bg-gradient-to-t from-black/30 via-black/5 to-transparent opacity-70 group-hover:opacity-60 transition-opacity" />
-                </div>
+        <div className="mt-14 grid grid-cols-1 gap-10 sm:grid-cols-2 lg:grid-cols-3">
+          {venueTypes.map((v) => {
+            const Icon = iconMap[v.slug] || Squares2X2Icon;
+            const imgSrc =
+              v.image && v.image.trim() !== "" ? v.image : VENUE_PLACEHOLDER_IMG;
 
-                {/* Title + Icon */}
-                <div className="mt-4 flex items-center justify-between">
-                  <h3 className="text-lg font-semibold text-gray-900 group-hover:text-[#288dcf] transition-colors">
-                    {v.name}
-                  </h3>
-                  <span className="ml-3 inline-flex h-9 w-9 items-center justify-center rounded-full bg-gray-100 ring-1 ring-gray-200 text-gray-600 group-hover:bg-[#288dcf] group-hover:text-white group-hover:ring-[#288dcf] transition-colors">
-                    <Icon className="h-5 w-5" aria-hidden="true" />
-                  </span>
-                </div>
-              </Card>
-            </Link>
-          );
-        })}
+            return (
+              <Link
+                key={v.slug}
+                to={`/venue-types/${v.slug}`}
+                className="group block"
+              >
+                <Card className="hover:shadow-xl hover:ring-gray-300 transition-all duration-300">
+                  {/* Image (with placeholder) */}
+                  <div className="relative h-48 w-full overflow-hidden rounded-md">
+                    <img
+                      src={imgSrc}
+                      alt={v.name}
+                      className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
+                    />
+                    <div className="absolute inset-0 bg-gradient-to-t from-black/30 via-black/5 to-transparent opacity-70 group-hover:opacity-60 transition-opacity" />
+                  </div>
+
+                  {/* Title + Icon */}
+                  <div className="mt-4 flex items-center justify-between">
+                    <h3 className="text-lg font-semibold text-gray-900 group-hover:text-[#288dcf] transition-colors">
+                      {v.name}
+                    </h3>
+                    <span className="ml-3 inline-flex h-9 w-9 items-center justify-center rounded-full bg-gray-100 ring-1 ring-gray-200 text-gray-600 group-hover:bg-[#288dcf] group-hover:text-white group-hover:ring-[#288dcf] transition-colors">
+                      <Icon className="h-5 w-5" aria-hidden="true" />
+                    </span>
+                  </div>
+                </Card>
+              </Link>
+            );
+          })}
+        </div>
       </div>
+
+      <PricingCTA />
+      <Footer />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add HeroHeader to venue type list and detail pages
- include HomeBanner with meeting link and PricingCTA for conversions
- append shared Footer on both pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be3fc3aa7c832ead7c29a0447509e4