### PR TITLE
Link venue types in drawer to detail pages

### DIFF
--- a/src/components/VenueList.jsx
+++ b/src/components/VenueList.jsx
@@ -1,6 +1,8 @@
 'use client';
 
+import { Link } from 'react-router-dom';
 import { ChevronRightIcon } from '@heroicons/react/20/solid';
+import { VENUE_PLACEHOLDER_IMG } from '../data/venueTypes.js';
 
 export default function VenueList({ items }) {
   return (
@@ -8,13 +10,27 @@ export default function VenueList({ items }) {
       role="list"
       className="divide-y divide-gray-100 overflow-hidden bg-white shadow-xs outline-1 outline-gray-900/5 sm:rounded-xl"
     >
-      {items.map((v) => (
-        <li key={v.name} className="relative flex justify-between gap-x-6 px-4 py-5 hover:bg-gray-50 sm:px-6">
-          <div className="min-w-0 flex-auto">
-            <p className="text-sm/6 font-semibold text-gray-900">{v.name}</p>
-          </div>
-        </li>
-      ))}
+      {items.map((v) => {
+        const imgSrc = v.image && v.image.trim() !== '' ? v.image : VENUE_PLACEHOLDER_IMG;
+        return (
+          <li key={v.name}>
+            <Link
+              to={`/venue-types/${v.slug}`}
+              className="flex items-center justify-between gap-x-6 px-4 py-5 hover:bg-gray-50 sm:px-6"
+            >
+              <div className="flex items-center gap-x-4">
+                <img
+                  src={imgSrc}
+                  alt={v.name}
+                  className="h-10 w-10 flex-none rounded object-cover"
+                />
+                <p className="text-sm font-semibold text-gray-900">{v.name}</p>
+              </div>
+              <ChevronRightIcon className="h-5 w-5 flex-none text-gray-400" aria-hidden="true" />
+            </Link>
+          </li>
+        );
+      })}
     </ul>
   );
 }

--- a/src/components/VenuesSection.jsx
+++ b/src/components/VenuesSection.jsx
@@ -4,21 +4,13 @@ import React, { useState } from 'react';
 import Drawer from './Drawer';
 import VenueList from './VenueList';
 import LandingSectionHeading from './LandingSectionHeading';
+import { venueTypes } from '../data/venueTypes.js';
 
 export default function VenuesSection() {
   const [drawerOpen, setDrawerOpen] = useState(false);
 
   // All Venues
-  const allVenues = [
-    { name: 'Airports' }, { name: 'Bars' }, { name: 'Billboards' }, { name: 'Casual Dining' },
-    { name: 'Convenience Stores' }, { name: 'Colleges & Universities' }, { name: 'Dispensaries' },
-    { name: 'DMVs' }, { name: "Doctor’s Offices" }, { name: 'Gas Stations' }, { name: 'Gyms' },
-    { name: 'Hotels' }, { name: 'Liquor Stores' }, { name: 'Malls' }, { name: 'Movie Theaters' },
-    { name: 'Office Buildings' }, { name: 'Pharmacies' }, { name: 'QSR' }, { name: 'Recreational Locations' },
-    { name: 'Retail' }, { name: 'Salons' }, { name: 'Schools' }, { name: 'Sports Entertainment' },
-    { name: 'Street Furniture' }, { name: 'Taxis & Rideshares' }, { name: 'Transit Stations' },
-    { name: 'Urban Panels' }, { name: 'Veterinary Offices' },
-  ];
+  const allVenues = venueTypes.map(({ slug, name, image }) => ({ slug, name, image }));
 
   // Top Venues
   const topVenues = [


### PR DESCRIPTION
## Summary
- Populate venue drawer from venueTypes data
- Each venue type links to its detail page and includes a thumbnail

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c319ae4490832ea1a40915879ef375