### PR TITLE
Add maintenance cover page for upgrade downtime

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,13 +3,18 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-
-    <title>BoardBid.ai — Book Digital Billboards in Minutes</title>
-    <meta name="description" content="BoardBid.ai is a modern DSP for launching digital billboard campaigns across the USA with real-time pricing and no agency delays.">
+    <title>BoardBid.ai — Upgrades in Progress</title>
+    <meta
+      name="description"
+      content="BoardBid.ai is temporarily offline while we roll out new upgrades. Please stay tuned for the relaunch."
+    />
 
     <!-- Open Graph -->
-    <meta property="og:title" content="BoardBid.ai" />
-    <meta property="og:description" content="Book digital billboard ads with one click. Modern DSP for startups and marketers." />
+    <meta property="og:title" content="BoardBid.ai — Upgrades in Progress" />
+    <meta
+      property="og:description"
+      content="BoardBid.ai is temporarily offline while we roll out new upgrades. Please stay tuned for the relaunch."
+    />
     <meta
       property="og:image"
       content="https://ik.imagekit.io/boardbid/BoardBid-OG.jpg?updatedAt=1757489348517"
@@ -23,12 +28,97 @@
 
     <!-- Favicon -->
     <link rel="icon" href="/favicon.ico" />
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
-    
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    />
+
+    <style>
+      :root {
+        color-scheme: light;
+        font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        background: radial-gradient(circle at top left, #f9fafb 0%, #f3f4f6 45%, #e5e7eb 100%);
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: transparent;
+        color: #111827;
+      }
+
+      .card {
+        max-width: 540px;
+        width: calc(100% - 3rem);
+        padding: 3rem 2.5rem;
+        border-radius: 24px;
+        background: rgba(255, 255, 255, 0.86);
+        box-shadow: 0 25px 50px -12px rgba(15, 23, 42, 0.35);
+        backdrop-filter: blur(12px);
+        text-align: center;
+      }
+
+      .tag {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.5rem 1rem;
+        border-radius: 999px;
+        font-size: 0.875rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: #1e3a8a;
+        background: rgba(59, 130, 246, 0.1);
+      }
+
+      h1 {
+        font-size: clamp(2.25rem, 4vw, 3rem);
+        margin: 1.75rem 0 1rem;
+        letter-spacing: -0.03em;
+      }
+
+      p {
+        margin: 0;
+        font-size: 1.05rem;
+        line-height: 1.65;
+        color: #4b5563;
+      }
+
+      .footer {
+        margin-top: 2.5rem;
+        font-size: 0.95rem;
+        color: #1f2937;
+      }
+
+      .footer a {
+        color: #1d4ed8;
+        text-decoration: none;
+        font-weight: 600;
+      }
+
+      .footer a:hover,
+      .footer a:focus {
+        text-decoration: underline;
+      }
+    </style>
   </head>
   <body>
-    <div id="root"></div>
-    <script type="module" src="/src/main.jsx"></script>
-    <script src="https://unpkg.com/@lottiefiles/lottie-player@latest/dist/lottie-player.js"></script>
+    <main class="card" role="status" aria-live="polite">
+      <div class="tag">🚧 Upgrades Underway</div>
+      <h1>We&rsquo;ll Be Right Back</h1>
+      <p>
+        The BoardBid.ai experience is getting a fresh upgrade to serve you better. During this short
+        pause, the rest of the site is taking a break. Please stay tuned—we&rsquo;ll be live again within a
+        few days.
+      </p>
+      <p class="footer">
+        Need a hand in the meantime? Reach us at
+        <a href="mailto:hello@boardbid.ai">hello@boardbid.ai</a>.
+      </p>
+    </main>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the Vite app bootstrapping with a static maintenance cover page
- style the message with a glassmorphism card, gradient background, and contact link while upgrades are in progress

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ca2d365450832e8647a96f93a5fcb5