### PR TITLE
Add runtime maintenance mode toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,20 @@ boardbid-ui/
    npm run build
    ```
 
+---
+
+## 🛠 Maintenance Mode Toggle
+
+The main site now reads a lightweight runtime config from [`public/app-config.json`](public/app-config.json). Update the
+`maintenanceMode` boolean in that file to switch between the full application and the maintenance splash screen—no rebuild
+required:
+
+- `true` &rarr; Serve the upgrades-in-progress message to all visitors.
+- `false` &rarr; Load the full React application as usual.
+
+You can also customise the maintenance copy, headline, and preview metadata in the same JSON file if you need to adjust the
+messaging while the site is offline.
+
 ## 🔐 Authentication
 
 This project uses [Clerk](https://clerk.com/docs/quickstarts/react) for user management. Provide both development and production publishable keys in your `.env`:

--- a/index.html
+++ b/index.html
@@ -1,125 +1,16 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>BoardBid.ai — Upgrades in Progress</title>
-    <meta
-      name="description"
-      content="BoardBid.ai is temporarily offline while we roll out new upgrades. Please stay tuned for the relaunch."
-    />
-
-    <!-- Open Graph -->
-    <meta property="og:title" content="BoardBid.ai — Upgrades in Progress" />
-    <meta
-      property="og:description"
-      content="BoardBid.ai is temporarily offline while we roll out new upgrades. Please stay tuned for the relaunch."
-    />
-    <meta
-      property="og:image"
-      content="https://ik.imagekit.io/boardbid/BoardBid-OG.jpg?updatedAt=1757489348517"
-    />
-    <meta property="og:url" content="https://boardbid.ai" />
-    <meta name="twitter:card" content="summary_large_image" />
-    <meta
-      name="twitter:image"
-      content="https://ik.imagekit.io/boardbid/BoardBid-OG.jpg?updatedAt=1757489348517"
-    />
-
-    <!-- Favicon -->
     <link rel="icon" href="/favicon.ico" />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap"
-      rel="stylesheet"
-    />
-
-    <style>
-      :root {
-        color-scheme: light;
-        font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-        background: linear-gradient(135deg, #d6eaf8 0%, #288dcf 100%);
-      }
-
-      body {
-        margin: 0;
-        min-height: 100vh;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        background: transparent;
-        color: #000;
-      }
-
-      .card {
-        max-width: 520px;
-        width: calc(100% - 3rem);
-        padding: 2.5rem 2rem;
-        border-radius: 20px;
-        background: rgba(255, 255, 255, 0.95);
-        box-shadow: 0 10px 30px rgba(0, 0, 0, 0.12);
-        backdrop-filter: blur(8px);
-        text-align: center;
-      }
-
-      .tag {
-        display: inline-flex;
-        align-items: center;
-        gap: 0.5rem;
-        padding: 0.35rem 0.9rem;
-        border-radius: 999px;
-        font-size: 0.8rem;
-        font-weight: 600;
-        text-transform: uppercase;
-        letter-spacing: 0.07em;
-        color: #333;
-        background: #d6eaf8;
-      }
-
-      h1 {
-        font-size: clamp(2rem, 4vw, 2.75rem);
-        margin: 1.5rem 0 0.9rem;
-        font-weight: 700;
-        color: #000;
-      }
-
-      p {
-        margin: 0;
-        font-size: 1rem;
-        line-height: 1.65;
-        color: #444;
-      }
-
-      .footer {
-        margin-top: 2rem;
-        font-size: 0.95rem;
-        color: #000;
-      }
-
-      .footer a {
-        color: #288dcf;
-        text-decoration: none;
-        font-weight: 600;
-      }
-
-      .footer a:hover,
-      .footer a:focus {
-        text-decoration: underline;
-      }
-    </style>
+    <title>BoardBid.ai</title>
   </head>
   <body>
-    <main class="card" role="status" aria-live="polite">
-      <div class="tag">🚧 Upgrades Underway</div>
-      <h1>We&rsquo;ll Be Right Back</h1>
-      <p>
-        The BoardBid.ai experience is getting a fresh upgrade to serve you better. During this short
-        pause, the rest of the site is taking a break. Please stay tuned—we&rsquo;ll be live again within a
-        few days.
-      </p>
-      <p class="footer">
-        Need a hand in the meantime? Reach us at
-        <a href="mailto:support@boardbid.ai">support@boardbid.ai</a>.
-      </p>
-    </main>
+    <div id="root"></div>
+    <noscript>
+      BoardBid.ai requires JavaScript to run. Please enable JavaScript in your browser settings.
+    </noscript>
+    <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>

--- a/public/app-config.json
+++ b/public/app-config.json
@@ -1,0 +1,16 @@
+{
+  "maintenanceMode": true,
+  "maintenance": {
+    "tag": "🚧 Upgrades Underway",
+    "heading": "We’ll Be Right Back",
+    "body": [
+      "The BoardBid.ai experience is getting a fresh upgrade to serve you better. During this short pause, the rest of the site is taking a break. Please stay tuned—we’ll be live again within a few days."
+    ],
+    "contactEmail": "support@boardbid.ai",
+    "meta": {
+      "title": "BoardBid.ai — Upgrades in Progress",
+      "description": "BoardBid.ai is temporarily offline while we roll out new upgrades. Please stay tuned for the relaunch.",
+      "image": "https://ik.imagekit.io/boardbid/BoardBid-OG.jpg?updatedAt=1757489348517"
+    }
+  }
+}

--- a/src/components/MaintenancePage.jsx
+++ b/src/components/MaintenancePage.jsx
@@ -1,0 +1,120 @@
+import { Helmet } from 'react-helmet-async';
+
+const pageStyles = {
+  wrapper: {
+    minHeight: '100vh',
+    margin: 0,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    background: 'linear-gradient(135deg, #d6eaf8 0%, #288dcf 100%)',
+    fontFamily: "'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+    color: '#000',
+    padding: '3rem 1.5rem',
+    boxSizing: 'border-box',
+  },
+  card: {
+    width: '100%',
+    maxWidth: '520px',
+    padding: '2.5rem 2rem',
+    borderRadius: '20px',
+    background: 'rgba(255, 255, 255, 0.95)',
+    boxShadow: '0 10px 30px rgba(0, 0, 0, 0.12)',
+    backdropFilter: 'blur(8px)',
+    textAlign: 'center',
+  },
+  tag: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: '0.5rem',
+    padding: '0.35rem 0.9rem',
+    borderRadius: '999px',
+    fontSize: '0.8rem',
+    fontWeight: 600,
+    textTransform: 'uppercase',
+    letterSpacing: '0.07em',
+    color: '#333',
+    background: '#d6eaf8',
+  },
+  heading: {
+    fontSize: 'clamp(2rem, 4vw, 2.75rem)',
+    margin: '1.5rem 0 0.9rem',
+    fontWeight: 700,
+    color: '#000',
+  },
+  paragraph: {
+    margin: 0,
+    fontSize: '1rem',
+    lineHeight: 1.65,
+    color: '#444',
+  },
+  footer: {
+    marginTop: '2rem',
+    fontSize: '0.95rem',
+    color: '#000',
+  },
+  link: {
+    color: '#288dcf',
+    textDecoration: 'none',
+    fontWeight: 600,
+  },
+};
+
+function MaintenancePage({
+  tag,
+  heading,
+  body,
+  contactEmail,
+  meta,
+}) {
+  const description = meta?.description ?? 'BoardBid.ai is temporarily offline for scheduled maintenance.';
+  const image = meta?.image ?? 'https://ik.imagekit.io/boardbid/BoardBid-OG.jpg?updatedAt=1757489348517';
+  const title = meta?.title ?? 'BoardBid.ai — Maintenance';
+  const paragraphs = Array.isArray(body) ? body : body ? [body] : [];
+
+  return (
+    <div style={pageStyles.wrapper} role="status" aria-live="polite">
+      <Helmet>
+        <title>{title}</title>
+        <meta name="description" content={description} />
+        <meta property="og:title" content={title} />
+        <meta property="og:description" content={description} />
+        <meta property="og:image" content={image} />
+        <meta property="og:url" content="https://boardbid.ai" />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:image" content={image} />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap"
+          rel="stylesheet"
+        />
+      </Helmet>
+      <main style={pageStyles.card}>
+        {tag ? <div style={pageStyles.tag}>{tag}</div> : null}
+        <h1 style={pageStyles.heading}>{heading}</h1>
+        {paragraphs.map((paragraph, index) => (
+          <p
+            // eslint-disable-next-line react/no-array-index-key
+            key={index}
+            style={{
+              ...pageStyles.paragraph,
+              marginTop: index === 0 ? 0 : '1rem',
+            }}
+          >
+            {paragraph}
+          </p>
+        ))}
+        {contactEmail ? (
+          <p style={pageStyles.footer}>
+            Need a hand in the meantime? Reach us at{' '}
+            <a style={pageStyles.link} href={`mailto:${contactEmail}`}>
+              {contactEmail}
+            </a>
+            .
+          </p>
+        ) : null}
+      </main>
+    </div>
+  );
+}
+
+export default MaintenancePage;


### PR DESCRIPTION
## Summary
- add a runtime `app-config.json` so the main site can switch between maintenance and live modes without redeploying
- guard the React router behind the config toggle and render a styled maintenance splash screen when required
- restore the Vite entrypoint markup and document how to flip the new maintenance boolean

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cba9958ed8832e8b89baf245fefa42